### PR TITLE
Use std::string_view as std::unordered_map keys.

### DIFF
--- a/modules/acq.cc
+++ b/modules/acq.cc
@@ -206,7 +206,7 @@ void Controller::encode_config()
 
     clear_and_insert(regs.shots, number_shots, ACQ_CORE_SHOTS_NB_MASK);
 
-    const static std::unordered_map<std::string, std::array<bool, 4>> trigger_types({
+    const static std::unordered_map<std::string_view, std::array<bool, 4>> trigger_types({
         /* CTL_FSM_ACQ_NOW, TRIG_CFG_HW_TRIG_EN, TRIG_CFG_SW_TRIG_EN, TRIG_CFG_HW_TRIG_SEL */
         {"immediate", {true, false, false, false}},
         {"external", {false, true, false, true}},

--- a/modules/lamp_v1.cc
+++ b/modules/lamp_v1.cc
@@ -105,7 +105,7 @@ void ControllerV1::encode_config()
 
     insert_bit(channel_regs.ctl, amp_enable, RTMLAMP_OHWR_REGS_CH_0_CTL_AMP_EN);
 
-    static const std::unordered_map<std::string, int> mode_options({
+    static const std::unordered_map<std::string_view, int> mode_options({
         {"none", -1},
         {"triangular", 0},
         {"square", 1},

--- a/modules/lamp_v2.cc
+++ b/modules/lamp_v2.cc
@@ -136,7 +136,7 @@ ControllerV2::~ControllerV2() = default;
 
 void ControllerV2::encode_config()
 {
-    static const std::unordered_map<std::string, int> mode_options({
+    static const std::unordered_map<std::string_view, int> mode_options({
         {"open-loop-dac", 0},
         {"open-loop-square", 1},
         {"closed-loop-pi_sp", 2},

--- a/util/decoders.cc
+++ b/util/decoders.cc
@@ -7,7 +7,7 @@
 
 #include "decoders.h"
 
-RegisterDecoder::RegisterDecoder(struct pcie_bars &bars, std::unordered_map<const char *, Printer> printers):
+RegisterDecoder::RegisterDecoder(struct pcie_bars &bars, std::unordered_map<std::string_view, Printer> printers):
     bars(bars),
     printers(printers)
 {

--- a/util/decoders.h
+++ b/util/decoders.h
@@ -43,8 +43,8 @@ class RegisterDecoder {
      *
      * int32_t is so far a generic enough value to be used here,
      * but int64_t can be considered if it ever becomes an issue */
-    std::unordered_map<std::string, int32_t> general_data;
-    std::unordered_map<std::string, std::vector<int32_t>> channel_data;
+    std::unordered_map<std::string_view, int32_t> general_data;
+    std::unordered_map<std::string_view, std::vector<int32_t>> channel_data;
     /* hold the order in which the data has been added to the maps,
      * which allows us to implement printing cleanly and prettily
      * while also using an unordered_map */
@@ -58,9 +58,9 @@ class RegisterDecoder {
     /* a device that has multiple channels will set this */
     std::optional<unsigned> number_of_channels;
 
-    std::unordered_map<const char *, Printer> printers;
+    std::unordered_map<std::string_view, Printer> printers;
 
-    RegisterDecoder(struct pcie_bars &, std::unordered_map<const char *, Printer>);
+    RegisterDecoder(struct pcie_bars &, std::unordered_map<std::string_view, Printer>);
     virtual void decode() = 0;
 
     void add_general(const char *, int32_t, bool = false);

--- a/util/printer.h
+++ b/util/printer.h
@@ -48,7 +48,7 @@ class Printer {
     void print(FILE *, bool, unsigned, T) const;
 };
 
-/* helper for defining std::unordered_map<const char *, Printer> */
+/* helper for defining std::unordered_map<std::string_view, Printer> */
 #define I(name, ...) {name, {name, __VA_ARGS__}}
 
 void print_reg_impl(FILE *f, bool v, unsigned &indent, const char *reg, unsigned offset);

--- a/util/util.cc
+++ b/util/util.cc
@@ -116,9 +116,10 @@ sign_extension_fn &sign_extend_function(unsigned width)
     }
 }
 
-std::string list_of_keys(const std::unordered_map<std::string, int> &m)
+std::string list_of_keys(const std::unordered_map<std::string_view, int> &m)
 {
     auto b = m.begin();
-    return std::accumulate(std::next(b), m.end(), b->first,
-        [](std::string a, std::pair<std::string, int> b) {return a + ", " + b.first;});
+    return std::accumulate(std::next(b), m.end(), std::string(b->first),
+        /* we know b.first.data() is safe to use here because it's guaranteed to be null terminated */
+        [](std::string a, auto b) { return a.append({", ", b.first.data()}); });
 }

--- a/util/util.h
+++ b/util/util.h
@@ -23,6 +23,6 @@ T extract_value(uint32_t value, uint32_t mask);
 typedef std::function<int32_t(uint32_t)> sign_extension_fn;
 sign_extension_fn &sign_extend_function(unsigned width);
 
-std::string list_of_keys(const std::unordered_map<std::string, int> &m);
+std::string list_of_keys(const std::unordered_map<std::string_view, int> &m);
 
 #endif


### PR DESCRIPTION
The unordered_maps that were using <const char *> as keys were working by accident, thanks to the linker making it so the identifier strings had the same pointer, due to deduplication (this only works for access from the library itself). The ones that were using <std::string> were working correctly, but for longer strings would lead to allocations for each map access. If we switch to <std::string_view>, we avoid allocations but still get the automatic std::hash specialization.