### PR TITLE
sdb: get_synthesis_info.

### DIFF
--- a/app/decode-reg.cc
+++ b/app/decode-reg.cc
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
         fputs(
             "Usage: decode-reg mode <mode specific options>\n\n"
             "Positional arguments:\n"
-            "mode      mode of operation ('reset', 'decode', 'ram', 'acq', 'lamp')\n",
+            "mode      mode of operation ('reset', 'build_info', 'decode', 'ram', 'acq', 'lamp')\n",
             stderr);
         return 1;
     }
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
     lamp_args.add_argument("-T").help("Trigger enable").scan<'u', unsigned>();
 
     argparse::ArgumentParser *pargs;
-    if (mode == "reset") {
+    if (mode == "reset" || mode == "build_info") {
         pargs = &parent_args;
     } else if (mode == "decode") {
         pargs = &decode_args;
@@ -128,6 +128,20 @@ int main(int argc, char *argv[])
 
     if (mode == "reset") {
         device_reset(&bars);
+        return 0;
+    }
+    if (mode == "build_info") {
+        auto build_info = get_synthesis_info(&bars);
+
+        for (auto &b: build_info) {
+            printf("name %s\n", b.name);
+            printf("    commit-id %s\n", b.commit);
+            if (b.tool_name[0]) printf("    tool-name %s\n", b.tool_name);
+            if (b.tool_version) printf("    tool-version 0x%08x\n", (unsigned)b.tool_version);
+            if (b.date) printf("    date 0x%08x\n", (unsigned)b.date);
+            if (b.user_name[0]) printf("    user-name %s\n", b.user_name);
+        }
+
         return 0;
     }
 

--- a/util/sdb-defs.h
+++ b/util/sdb-defs.h
@@ -23,6 +23,15 @@ struct sdb_device_info {
     uint8_t abi_ver_minor;
 };
 
+struct sdb_synthesis_info {
+    char name[17];
+    char commit[33];
+    char tool_name[9];
+    uint32_t tool_version;
+    uint32_t date;
+    char user_name[16];
+};
+
 #ifdef __cplusplus
 typedef std::function<bool(const struct sdb_device_info &)> device_match_fn;
 #endif

--- a/util/util_sdb.h
+++ b/util/util_sdb.h
@@ -9,6 +9,7 @@
 #define UPPER_SDB_H
 
 #include <optional>
+#include <vector>
 
 #include "pcie-defs.h"
 #include "sdb-defs.h"
@@ -19,5 +20,7 @@ std::optional<struct sdb_device_info> read_sdb(struct pcie_bars *, device_match_
 std::optional<struct sdb_device_info> read_sdb(struct pcie_bars *, device_match_fn, unsigned);
 
 bool print_sdb(const struct sdb_device_info &);
+
+std::vector<struct sdb_synthesis_info> get_synthesis_info(struct pcie_bars *);
 
 #endif


### PR DESCRIPTION
This function is used to obtain information about the build, in order to aid in verifying deployments were done correctly, and general debugging and documentation.