### PR TITLE
fofb_shaper_filt: add module.

### DIFF
--- a/app/decode-reg.cc
+++ b/app/decode-reg.cc
@@ -22,6 +22,7 @@
 #include "modules/bpm_swap.h"
 #include "modules/fofb_cc.h"
 #include "modules/fofb_processing.h"
+#include "modules/fofb_shaper_filt.h"
 #include "modules/lamp.h"
 #include "modules/orbit_intlk.h"
 #include "modules/pos_calc.h"
@@ -182,6 +183,8 @@ int main(int argc, char *argv[])
             dec = std::make_unique<fofb_cc::Core>(bars);
         } else if (type == "fofb_processing") {
             dec = std::make_unique<fofb_processing::Core>(bars);
+        } else if (type == "fofb_shaper_filt") {
+            dec = std::make_unique<fofb_shaper_filt::Core>(bars);
         } else if (type == "sys_id") {
             dec = std::make_unique<sys_id::Core>(bars);
         } else if (type == "trigger_iface") {

--- a/include/modules/fofb_shaper_filt.h
+++ b/include/modules/fofb_shaper_filt.h
@@ -1,0 +1,59 @@
+#ifndef FOFB_SHAPER_FILT_H
+#define FOFB_SHAPER_FILT_H
+
+#include <vector>
+#include <memory>
+
+#include "controllers.h"
+#include "decoders.h"
+
+namespace fofb_shaper_filt {
+
+struct filter_coefficients {
+    filter_coefficients();
+    void set_num_biquads(size_t);
+    std::vector<std::vector<double>> values;
+};
+
+/* forward declaration */
+struct wb_fofb_shaper_filt_regs;
+
+class Core: public RegisterDecoder {
+    std::unique_ptr<struct wb_fofb_shaper_filt_regs> regs_storage;
+    struct wb_fofb_shaper_filt_regs &regs;
+
+    void decode() override;
+    void read_monitors() override;
+    void decode_monitors() override;
+
+  public:
+    Core(struct pcie_bars &);
+    ~Core();
+
+    void print(FILE *, bool) const override;
+
+    filter_coefficients coefficients;
+};
+
+class Controller: public RegisterController {
+  protected:
+    std::unique_ptr<struct wb_fofb_shaper_filt_regs> regs_storage;
+    struct wb_fofb_shaper_filt_regs &regs;
+
+    unsigned fixed_point_coeff, num_biquads;
+
+    void set_devinfo_callback() override;
+    void encode_params() override;
+
+  public:
+    Controller(struct pcie_bars &);
+    ~Controller();
+
+    void write_params() override;
+
+    filter_coefficients coefficients;
+};
+
+} /* namespace fofb_shaper_filt */
+
+#endif

--- a/include/modules/meson.build
+++ b/include/modules/meson.build
@@ -5,6 +5,7 @@ install_headers(
     'bpm_swap.h',
     'fofb_cc.h',
     'fofb_processing.h',
+    'fofb_shaper_filt.h',
     'lamp.h',
     'orbit_intlk.h',
     'pos_calc.h',

--- a/modules/fofb_shaper_filt.cc
+++ b/modules/fofb_shaper_filt.cc
@@ -1,0 +1,153 @@
+#include <algorithm>
+#include <stdexcept>
+
+#include "pcie.h"
+#include "printer.h"
+#include "util.h"
+#include "modules/fofb_shaper_filt.h"
+
+namespace fofb_shaper_filt {
+
+#include "hw/wb_fofb_shaper_filt_regs.h"
+
+static_assert(WB_FOFB_SHAPER_FILT_REGS_CH_SIZE + WB_FOFB_SHAPER_FILT_REGS_CH == offsetof(wb_fofb_shaper_filt_regs, ch[1]));
+static_assert(WB_FOFB_SHAPER_FILT_REGS_NUM_BIQUADS == offsetof(wb_fofb_shaper_filt_regs, num_biquads));
+
+namespace {
+    const size_t
+        NUM_CHANNELS = 12,
+        NUM_COEFFS =  sizeof(wb_fofb_shaper_filt_regs::ch::coeffs) / sizeof(wb_fofb_shaper_filt_regs::ch::coeffs::val),
+        NUM_BIQUADS = 10,
+        COEFFS_PER_BIQUAD = 5,
+        UNUSED_PER_BIQUAD = 3,
+        TOTAL_PER_BIQUAD = COEFFS_PER_BIQUAD + UNUSED_PER_BIQUAD;
+    static_assert(NUM_COEFFS == NUM_BIQUADS * TOTAL_PER_BIQUAD);
+
+    constexpr unsigned FOFB_SHAPER_FILT_DEVID = 0xf65559b2;
+    struct sdb_device_info ref_devinfo = {
+        .vendor_id = LNLS_VENDORID,
+        .device_id = FOFB_SHAPER_FILT_DEVID,
+        .abi_ver_major = 1
+    };
+}
+
+filter_coefficients::filter_coefficients():
+  values(NUM_CHANNELS)
+{
+}
+
+void filter_coefficients::set_num_biquads(size_t num_biquads)
+{
+    for (auto &c: values) c.resize(num_biquads * COEFFS_PER_BIQUAD);
+}
+
+Core::Core(struct pcie_bars &bars):
+    RegisterDecoder(bars, ref_devinfo, { }),
+    CONSTRUCTOR_REGS(struct wb_fofb_shaper_filt_regs)
+{
+    set_read_dest(regs);
+    number_of_channels = NUM_CHANNELS;
+}
+Core::~Core() = default;
+
+/* no monitored values */
+void Core::read_monitors()
+{
+}
+void Core::decode_monitors()
+{
+}
+
+void Core::decode()
+{
+    uint32_t t;
+    add_general("NUM_BIQUADS", regs.num_biquads);
+    unsigned num_biquads = regs.num_biquads;
+
+    t = regs.coeffs_fp_repr;
+    uint32_t int_width = extract_value<uint8_t>(t, WB_FOFB_SHAPER_FILT_REGS_COEFFS_FP_REPR_INT_WIDTH_MASK);
+    add_general("INT_WIDTH", int_width);
+    add_general("FRAC_WIDTH", extract_value<uint8_t>(t, WB_FOFB_SHAPER_FILT_REGS_COEFFS_FP_REPR_FRAC_WIDTH_MASK));
+
+    uint32_t fixed_point_coeff = 32 - int_width;
+
+    coefficients.set_num_biquads(num_biquads);
+
+    for (unsigned i = 0; i < NUM_CHANNELS; i++) {
+        for (unsigned j = 0; j < num_biquads; j++) {
+            for (unsigned k = 0; k < COEFFS_PER_BIQUAD; k++) {
+                coefficients.values[i][k + COEFFS_PER_BIQUAD * j] =
+                    fixed2float(regs.ch[i].coeffs[k + TOTAL_PER_BIQUAD * j].val, fixed_point_coeff);
+            }
+        }
+    }
+}
+
+void Core::print(FILE *f, bool verbose) const
+{
+    RegisterDecoder::print(f, verbose);
+
+    if (channel) {
+        fprintf(f, "channel %u filter coefficients: ", *channel);
+        for (auto c: coefficients.values[*channel]) {
+            fprintf(f, "%lf, ", c);
+        }
+        fputs("\n", f);
+
+        if (verbose) {
+            fprintf(f, "channel %u raw filter coefficients: ", *channel);
+            for (auto c: regs.ch[*channel].coeffs) {
+                fprintf(f, "%#08x, ", (unsigned)c.val);
+            }
+            fputs("\n", f);
+        }
+    }
+}
+
+Controller::Controller(struct pcie_bars &bars):
+    RegisterController(bars, ref_devinfo),
+    CONSTRUCTOR_REGS(struct wb_fofb_shaper_filt_regs)
+{
+    set_read_dest(regs);
+
+    coefficients.set_num_biquads(NUM_BIQUADS);
+}
+Controller::~Controller() = default;
+
+void Controller::set_devinfo_callback()
+{
+    regs.coeffs_fp_repr = bar4_read(&bars, addr + WB_FOFB_SHAPER_FILT_REGS_COEFFS_FP_REPR);
+    fixed_point_coeff = 32 - extract_value<uint8_t>(regs.coeffs_fp_repr, WB_FOFB_SHAPER_FILT_REGS_COEFFS_FP_REPR_INT_WIDTH_MASK);
+
+    regs.num_biquads = bar4_read(&bars, addr + WB_FOFB_SHAPER_FILT_REGS_NUM_BIQUADS);
+    num_biquads = regs.num_biquads;
+}
+
+void Controller::encode_params()
+{
+    for (unsigned i = 0; i < NUM_CHANNELS; i++) {
+        for (unsigned j = 0; j < num_biquads; j++) {
+            for (unsigned k = 0; k < COEFFS_PER_BIQUAD; k++) {
+                regs.ch[i].coeffs[k + TOTAL_PER_BIQUAD * j].val =
+                    float2fixed(coefficients.values[i][k + COEFFS_PER_BIQUAD * j], fixed_point_coeff);
+            }
+        }
+    }
+}
+
+void Controller::write_params()
+{
+    encode_params();
+
+    for (unsigned i = 0; i < NUM_CHANNELS; i++) {
+        for (unsigned j = 0; j < num_biquads; j++) {
+            bar4_write_v(
+                &bars,
+                addr + WB_FOFB_SHAPER_FILT_REGS_CH_COEFFS + i * sizeof(regs.ch[0]) + TOTAL_PER_BIQUAD * j * sizeof(uint32_t),
+                &regs.ch[i].coeffs[TOTAL_PER_BIQUAD * j].val,
+                COEFFS_PER_BIQUAD * sizeof(uint32_t));
+        }
+    }
+}
+
+} /* namespace fofb_shaper_filt */

--- a/modules/hw/wb_fofb_shaper_filt_regs.h
+++ b/modules/hw/wb_fofb_shaper_filt_regs.h
@@ -1,0 +1,101 @@
+#ifndef __CHEBY__WB_FOFB_SHAPER_FILT_REGS__H__
+#define __CHEBY__WB_FOFB_SHAPER_FILT_REGS__H__
+#define WB_FOFB_SHAPER_FILT_REGS_SIZE 8200 /* 0x2008 */
+
+/* None */
+#define WB_FOFB_SHAPER_FILT_REGS_CH 0x0UL
+#define WB_FOFB_SHAPER_FILT_REGS_CH_SIZE 512 /* 0x200 */
+
+/* Coefficients for the 'num_biquads' IIR internal biquads.
+
+Each biquad takes 5 coefficients: b0, b1, b2, a1 and a2 (a0 = 1).
+The 'coeffs' array should be populated in the following manner:
+
+  coeffs[0 + 8*{biquad_idx}] = b0 of biquad {biquad_idx}
+  coeffs[1 + 8*{biquad_idx}] = b1 of biquad {biquad_idx}
+  coeffs[2 + 8*{biquad_idx}] = b2 of biquad {biquad_idx}
+  coeffs[3 + 8*{biquad_idx}] = a1 of biquad {biquad_idx}
+  coeffs[4 + 8*{biquad_idx}] = a2 of biquad {biquad_idx}
+  coeffs[5 + 8*{biquad_idx}] = unused
+  coeffs[6 + 8*{biquad_idx}] = unused
+  coeffs[7 + 8*{biquad_idx}] = unused
+
+NOTE: This ABI supports up to 20th order filters, but only the
+coefficients corresponding to the first 'num_biquads' biquads are
+meaningful for the gateware.
+ */
+#define WB_FOFB_SHAPER_FILT_REGS_CH_COEFFS 0x0UL
+#define WB_FOFB_SHAPER_FILT_REGS_CH_COEFFS_SIZE 4 /* 0x4 */
+
+/* Coefficient value using 'coeffs_fp_repr' fixed-point
+representation. It should be aligned to the left.
+ */
+#define WB_FOFB_SHAPER_FILT_REGS_CH_COEFFS_VAL 0x0UL
+
+/* The number of internal biquads each IIR filter has.
+ */
+#define WB_FOFB_SHAPER_FILT_REGS_NUM_BIQUADS 0x2000UL
+
+/* Fixed-point signed (2's complement) representation of coefficients.
+The coefficients should be aligned to the left. The fixed-point
+position is then given by 32 - 'int_width' (i.e. one should divide
+this register's content by 2**{32 - 'int_width'} to get the
+represented decimal number.
+ */
+#define WB_FOFB_SHAPER_FILT_REGS_COEFFS_FP_REPR 0x2004UL
+#define WB_FOFB_SHAPER_FILT_REGS_COEFFS_FP_REPR_INT_WIDTH_MASK 0x1fUL
+#define WB_FOFB_SHAPER_FILT_REGS_COEFFS_FP_REPR_INT_WIDTH_SHIFT 0
+#define WB_FOFB_SHAPER_FILT_REGS_COEFFS_FP_REPR_FRAC_WIDTH_MASK 0x3e0UL
+#define WB_FOFB_SHAPER_FILT_REGS_COEFFS_FP_REPR_FRAC_WIDTH_SHIFT 5
+
+#ifndef __ASSEMBLER__
+struct wb_fofb_shaper_filt_regs {
+  /* [0x0]: REPEAT (no description) */
+  struct ch {
+    /* [0x0]: MEMORY Coefficients for the 'num_biquads' IIR internal biquads.
+
+Each biquad takes 5 coefficients: b0, b1, b2, a1 and a2 (a0 = 1).
+The 'coeffs' array should be populated in the following manner:
+
+  coeffs[0 + 8*{biquad_idx}] = b0 of biquad {biquad_idx}
+  coeffs[1 + 8*{biquad_idx}] = b1 of biquad {biquad_idx}
+  coeffs[2 + 8*{biquad_idx}] = b2 of biquad {biquad_idx}
+  coeffs[3 + 8*{biquad_idx}] = a1 of biquad {biquad_idx}
+  coeffs[4 + 8*{biquad_idx}] = a2 of biquad {biquad_idx}
+  coeffs[5 + 8*{biquad_idx}] = unused
+  coeffs[6 + 8*{biquad_idx}] = unused
+  coeffs[7 + 8*{biquad_idx}] = unused
+
+NOTE: This ABI supports up to 20th order filters, but only the
+coefficients corresponding to the first 'num_biquads' biquads are
+meaningful for the gateware.
+ */
+    struct coeffs {
+      /* [0x0]: REG (rw) Coefficient value using 'coeffs_fp_repr' fixed-point
+representation. It should be aligned to the left.
+ */
+      uint32_t val;
+    } coeffs[80];
+
+    /* padding to: 0 words */
+    uint32_t __padding_0[48];
+  } ch[12];
+
+  /* padding to: 0 words */
+  uint32_t __padding_0[512];
+
+  /* [0x2000]: REG (ro) The number of internal biquads each IIR filter has.
+ */
+  uint32_t num_biquads;
+
+  /* [0x2004]: REG (ro) Fixed-point signed (2's complement) representation of coefficients.
+The coefficients should be aligned to the left. The fixed-point
+position is then given by 32 - 'int_width' (i.e. one should divide
+this register's content by 2**{32 - 'int_width'} to get the
+represented decimal number.
+ */
+  uint32_t coeffs_fp_repr;
+};
+#endif /* !__ASSEMBLER__*/
+
+#endif /* __CHEBY__WB_FOFB_SHAPER_FILT_REGS__H__ */

--- a/modules/meson.build
+++ b/modules/meson.build
@@ -4,6 +4,7 @@ modules_src = [
   'bpm_swap.cc',
   'fofb_cc.cc',
   'fofb_processing.cc',
+  'fofb_shaper_filt.cc',
   'lamp.cc',
   'orbit_intlk.cc',
   'pos_calc.cc',


### PR DESCRIPTION
The static assertion for the amount of coefficients was written to make sure the sizeof expressions were correct, but it also works as a check for if the ABI ever changes.