### PR TITLE
decode-reg: check if build_info exists in quiet mode.

### DIFF
--- a/app/decode-reg.cc
+++ b/app/decode-reg.cc
@@ -154,6 +154,11 @@ int main(int argc, char *argv[])
     if (mode == "build_info") {
         auto build_info = get_synthesis_info(&bars);
 
+        if (build_info.empty()) {
+            fputs("no SDB was found\n", stderr);
+            return 1;
+        }
+
         if (args.is_used("-q"))
             puts(build_info[0].name);
         else


### PR DESCRIPTION
In an inconsistent link state, it is occasionally possible to open the resource file for a given board, even though it does not correctly report its synthesis information. In this situation, build_info will be empty and a segmentation fault will probably happen in `puts`. Avoid crashing in such cases by not assuming a value will always exist.