### PR TITLE
decode-reg: fix misleading pos_calc output.

### DIFF
--- a/app/decode-reg.cc
+++ b/app/decode-reg.cc
@@ -241,6 +241,14 @@ int main(int argc, char *argv[])
                 }
 
                 dec->get_data();
+
+                if (type == "pos_calc") {
+                    /* force module to actually read these registers */
+                    auto dec_pos_calc = dynamic_cast<pos_calc::Core *>(dec.get());
+                    dec_pos_calc->fifo_empty();
+                    dec_pos_calc->get_fifo_amps();
+                }
+
                 dec->print(stdout, verbose);
             } while (watch);
         } else {


### PR DESCRIPTION
Using the decode mode with pos_calc::Core would print register fields belonging to the amplitude FIFO (both status and values), but read from zeroed-out memory, instead of from the hardware. Beyond being misleading, it's incomplete information. Therefore, we force the core to read amplitude FIFO information from the hardware.