### PR TITLE
templates: add module template.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,5 +33,6 @@ header_dir = 'uhal'
 
 subdir('include')
 subdir('util')
+subdir('templates')
 subdir('modules')
 subdir('app')

--- a/templates/add_module.sh
+++ b/templates/add_module.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -eu
+
+module=$1
+reporoot="$(git rev-parse --show-toplevel)"
+
+upper_case() {
+	echo "$1" | tr '[:lower:]' '[:upper:]'
+}
+
+isubstitution=s,mod_template\\.h,modules/$module.h,
+substitution=s/mod_template/$module/g
+Substitution=s/$(upper_case mod_template)/$(upper_case $module)/g
+
+sed -e $isubstitution -e $substitution -e $Substitution $reporoot/templates/mod_template.cc > $reporoot/modules/$module.cc
+sed -e $substitution -e $Substitution $reporoot/templates/mod_template.h > $reporoot/include/modules/$module.h

--- a/templates/meson.build
+++ b/templates/meson.build
@@ -1,0 +1,9 @@
+templates_src = [
+  'mod_template.cc',
+]
+templates_lib = static_library(
+  'templates',
+  templates_src,
+  dependencies: [utilities],
+  install: false
+)

--- a/templates/mod_template.cc
+++ b/templates/mod_template.cc
@@ -1,0 +1,41 @@
+#include "printer.h"
+#include "util.h"
+#include "mod_template.h"
+
+namespace mod_template {
+
+struct mod_template {
+};
+
+namespace {
+    constexpr unsigned MOD_TEMPLATE_DEVID = 0xdeadbeef;
+    struct sdb_device_info ref_devinfo = {
+        .vendor_id = LNLS_VENDORID,
+        .device_id = MOD_TEMPLATE_DEVID,
+        .abi_ver_major = 0
+    };
+}
+
+Core::Core(struct pcie_bars &bars):
+    RegisterDecoder(bars, ref_devinfo, {
+    }),
+    CONSTRUCTOR_REGS(struct mod_template)
+{
+    set_read_dest(regs);
+}
+Core::~Core() = default;
+
+void Core::decode()
+{
+}
+
+Controller::Controller(struct pcie_bars &bars):
+    RegisterDecoderController(bars, ref_devinfo, &dec),
+    CONSTRUCTOR_REGS(struct mod_template),
+    dec(bars)
+{
+    set_read_dest(regs);
+}
+Controller::~Controller() = default;
+
+} /* namespace mod_template */

--- a/templates/mod_template.h
+++ b/templates/mod_template.h
@@ -1,0 +1,37 @@
+#ifndef MOD_TEMPLATE_H
+#define MOD_TEMPLATE_H
+
+#include <memory>
+
+#include "controllers.h"
+#include "decoders.h"
+
+namespace mod_template {
+
+struct mod_template;
+
+class Core: public RegisterDecoder {
+    std::unique_ptr<struct mod_template> regs_storage;
+    struct mod_template &regs;
+
+    void decode() override;
+
+  public:
+    Core(struct pcie_bars &);
+    ~Core() override;
+};
+
+class Controller: public RegisterDecoderController {
+    std::unique_ptr<struct mod_template> regs_storage;
+    struct mod_template &regs;
+
+    Core dec;
+
+  public:
+    Controller(struct pcie_bars &);
+    ~Controller();
+};
+
+} /* namespace mod_template */
+
+#endif


### PR DESCRIPTION
This makes it simpler to add the boilerplate for new modules, instead of having to copy an existing file and remember to change all the required places.

The script doesn't handle adding the modules to meson.build yet, but that might be an interesting future direction.