### PR TITLE
afc_timing: add assertion to catch hardware state issues.

### DIFF
--- a/modules/afc_timing.cc
+++ b/modules/afc_timing.cc
@@ -138,7 +138,11 @@ void Core::decode()
         add_channel("CH_POL", i, get_bit(t, TIMING_AMC0_POL));
         add_channel("CH_LOG", i, get_bit(t, TIMING_AMC0_LOG));
         add_channel("CH_ITL", i, get_bit(t, TIMING_AMC0_ITL));
-        add_channel("CH_SRC", i, extract_value<uint8_t>(t, TIMING_AMC0_SRC_MASK));
+
+        auto ch_src = extract_value<uint8_t>(t, TIMING_AMC0_SRC_MASK);
+        assert(ch_src < Controller::sources_list.size());
+        add_channel("CH_SRC", i, ch_src);
+
         add_channel("CH_DIR", i, get_bit(t, TIMING_AMC0_DIR));
 
         add_channel("CH_PULSES", i, trigger.pulses);


### PR DESCRIPTION
Wishbone timeouts, board disconnects, and other possible issues cause reads from BAR4 to return words with all bits set. Differentiating that from a valid value isn't possible without more context. If we have already decoded the SDB and are monitoring some FPGA module, we know some fields which have maximum values, so if they are above that, we know an issue has happened.

The BPM and FOFB boards already have such a check, thanks to the ACQ module.