### PR TITLE
Add clang-tidy to the code base

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,19 @@
+Checks: "bugprone*,\
+         cert-*,\
+         clang-analyzer*,\
+         concurrency-*,\
+         modernize-*,\
+         performance-*,\
+         readability-*,\
+         -bugprone-empty-catch,\
+         -concurrency-mt-unsafe,\
+         -modernize-use-trailing-return-type,\
+         -performance-avoid-endl,\
+         -readability-braces-around-statements,\
+         -readability-identifier-length,\
+         -readability-implicit-bool-conversion,\
+         -readability-named-parameter,\
+         "
+
+HeaderFilterRegex: "(util|modules)/[^/]*\\.h"
+WarningsAsErrors: "*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,19 @@
+Checks: "bugprone*,\
+         cert-*,\
+         clang-analyzer*,\
+         concurrency-*,\
+         modernize-*,\
+         performance-*,\
+         readability-*,\
+         -bugprone-empty-catch,\
+         -concurrency-mt-unsafe,\
+         -modernize-use-trailing-return-type,\
+         -performance-avoid-endl,\
+         -readability-braces-around-statements,\
+         -readability-identifier-length,\
+         -readability-implicit-bool-conversion,\
+         -readability-named-parameter,\
+         "
+
+HeaderFilterRegex: "(util|include/modules)/[^/]*\\.h"
+WarningsAsErrors: "*"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,6 +19,19 @@ jobs:
       fail-fast: false
       matrix:
         tool:
+          # clang-tidy is more extensive and the list of checks isn't final, so fixing all of them at once isn't tractable;
+          # therefore, the job doesn't fail due to clang-tidy, it's simply informative
+          - packages: "clang-tidy"
+            command: "clang-tidy '--warnings-as-errors=-*' -p build/ $(git ls-files | grep '\\.c\\+$')"
+          # however, we should check that the changed lines of code don't have any tidy warnings
+          - packages: "clang-tidy"
+            command: |
+              if [ -n \"$GITHUB_BASE_REF\" ]; then
+                git diff -U0 origin/$GITHUB_BASE_REF > diff
+                clang-tidy-diff -p1 -config-file .clang-tidy -path build/ < diff > result && exitcode=0 || exitcode=$?
+                cat result
+                exit $exitcode
+              fi
           # cppcheck doesn't check as much, so we can make the job fail because of it;
           # tests are skipped due to issues with Catch2 headers
           - packages: "cppcheck"

--- a/app/decode-reg.cc
+++ b/app/decode-reg.cc
@@ -1,4 +1,4 @@
-#include <inttypes.h>
+#include <cinttypes>
 
 #include <algorithm>
 #include <chrono>
@@ -280,7 +280,7 @@ int main(int argc, char *argv[])
 
                 if (type == "pos_calc") {
                     /* force module to actually read these registers */
-                    auto dec_pos_calc = dynamic_cast<pos_calc::Core *>(dec.get());
+                    auto *dec_pos_calc = dynamic_cast<pos_calc::Core *>(dec.get());
                     dec_pos_calc->fifo_empty();
                     dec_pos_calc->get_fifo_amps();
                 }

--- a/app/decode-reg.cc
+++ b/app/decode-reg.cc
@@ -1,4 +1,4 @@
-#include <inttypes.h>
+#include <cinttypes>
 
 #include <algorithm>
 #include <chrono>
@@ -369,7 +369,7 @@ int main(int argc, char *argv[])
 
                 if (type == "pos_calc") {
                     /* force module to actually read these registers */
-                    auto dec_pos_calc
+                    auto *dec_pos_calc
                         = dynamic_cast<pos_calc::Core *>(dec.get());
                     dec_pos_calc->fifo_empty();
                     dec_pos_calc->get_fifo_amps();

--- a/include/modules/afc_timing.h
+++ b/include/modules/afc_timing.h
@@ -39,7 +39,7 @@ class Controller: public RegisterDecoderController {
         uint8_t n1, hs_div;
     } rtm_clock = {}, afc_clock = {};
 
-    bool set_freq(double, struct Controller::clock &);
+    static bool set_freq(double, struct Controller::clock &);
 
   public:
     Controller(struct pcie_bars &);

--- a/include/modules/afc_timing.h
+++ b/include/modules/afc_timing.h
@@ -39,7 +39,7 @@ class Controller : public RegisterDecoderController {
         uint8_t n1, hs_div;
     } rtm_clock = { }, afc_clock = { };
 
-    bool set_freq(double, struct Controller::clock &);
+    static bool set_freq(double, struct Controller::clock &);
 
 public:
     Controller(struct pcie_bars &);

--- a/include/modules/fofb_processing.h
+++ b/include/modules/fofb_processing.h
@@ -22,7 +22,7 @@ class Core: public RegisterDecoder {
 
   public:
     Core(struct pcie_bars &);
-    ~Core();
+    ~Core() override;
 
     std::vector<int32_t> ref_orb_x, ref_orb_y;
     std::vector<std::vector<double>> coefficients_x, coefficients_y;

--- a/include/modules/fofb_processing.h
+++ b/include/modules/fofb_processing.h
@@ -22,7 +22,7 @@ class Core : public RegisterDecoder {
 
 public:
     Core(struct pcie_bars &);
-    ~Core();
+    ~Core() override;
 
     std::vector<int32_t> ref_orb_x, ref_orb_y;
     std::vector<std::vector<double>> coefficients_x, coefficients_y;

--- a/include/modules/fofb_shaper_filt.h
+++ b/include/modules/fofb_shaper_filt.h
@@ -28,7 +28,7 @@ class Core: public RegisterDecoder {
 
   public:
     Core(struct pcie_bars &);
-    ~Core();
+    ~Core() override;
 
     void print(FILE *, bool) const override;
 

--- a/include/modules/fofb_shaper_filt.h
+++ b/include/modules/fofb_shaper_filt.h
@@ -28,7 +28,7 @@ class Core : public RegisterDecoder {
 
 public:
     Core(struct pcie_bars &);
-    ~Core();
+    ~Core() override;
 
     void print(FILE *, bool) const override;
 

--- a/include/modules/lamp.h
+++ b/include/modules/lamp.h
@@ -22,7 +22,7 @@ class Core: public RegisterDecoder {
 
   public:
     Core(struct pcie_bars &);
-    ~Core();
+    ~Core() override;
 };
 
 class Controller: public RegisterDecoderController {

--- a/include/modules/lamp.h
+++ b/include/modules/lamp.h
@@ -22,7 +22,7 @@ class Core : public RegisterDecoder {
 
 public:
     Core(struct pcie_bars &);
-    ~Core();
+    ~Core() override;
 };
 
 class Controller : public RegisterDecoderController {

--- a/include/modules/si57x_ctrl.h
+++ b/include/modules/si57x_ctrl.h
@@ -36,7 +36,7 @@ class Controller: public RegisterDecoderController {
     /** The device's startup frequency. */
     double fstartup;
     /** The device's internal crystal frequency. */
-    double fxtal;
+    double fxtal{0};
 
     /** Update all registers and return state of busy flag. */
     bool get_busy();

--- a/include/modules/si57x_ctrl.h
+++ b/include/modules/si57x_ctrl.h
@@ -36,7 +36,7 @@ class Controller : public RegisterDecoderController {
     /** The device's startup frequency. */
     double fstartup;
     /** The device's internal crystal frequency. */
-    double fxtal;
+    double fxtal { 0 };
 
     /** Update all registers and return state of busy flag. */
     bool get_busy();

--- a/include/modules/sysid.h
+++ b/include/modules/sysid.h
@@ -28,7 +28,7 @@ class Core: public RegisterDecoder {
 
   public:
     Core(struct pcie_bars &);
-    ~Core();
+    ~Core() override;
 
     void print(FILE *, bool) const override;
 

--- a/include/modules/sysid.h
+++ b/include/modules/sysid.h
@@ -28,7 +28,7 @@ class Core : public RegisterDecoder {
 
 public:
     Core(struct pcie_bars &);
-    ~Core();
+    ~Core() override;
 
     void print(FILE *, bool) const override;
 

--- a/include/modules/trigger_iface.h
+++ b/include/modules/trigger_iface.h
@@ -21,7 +21,7 @@ class Core: public RegisterDecoder {
 
   public:
     Core(struct pcie_bars &);
-    ~Core();
+    ~Core() override;
 };
 
 class Controller: public RegisterController {

--- a/include/modules/trigger_iface.h
+++ b/include/modules/trigger_iface.h
@@ -21,7 +21,7 @@ class Core : public RegisterDecoder {
 
 public:
     Core(struct pcie_bars &);
-    ~Core();
+    ~Core() override;
 };
 
 class Controller : public RegisterController {

--- a/include/modules/trigger_mux.h
+++ b/include/modules/trigger_mux.h
@@ -21,7 +21,7 @@ class Core: public RegisterDecoder {
 
   public:
     Core(struct pcie_bars &);
-    ~Core();
+    ~Core() override;
 };
 
 class Controller: public RegisterController {

--- a/include/modules/trigger_mux.h
+++ b/include/modules/trigger_mux.h
@@ -21,7 +21,7 @@ class Core : public RegisterDecoder {
 
 public:
     Core(struct pcie_bars &);
-    ~Core();
+    ~Core() override;
 };
 
 class Controller : public RegisterController {

--- a/modules/acq.cc
+++ b/modules/acq.cc
@@ -21,7 +21,7 @@ const size_t acq_ram_per_core = acq_ram / max_acq_cores;
 class MemoryAllocator {
     std::unordered_map<struct pcie_bars *, int> counts;
 
-    MemoryAllocator() { }
+    MemoryAllocator() = default;
 
 public:
     std::array<size_t, 2> get_range(struct pcie_bars &bars)
@@ -218,7 +218,7 @@ void Core::decode()
     /* acquisition channel control */
     t = regs.acq_chan_ctl;
     /* will be used to determine how many channels to show in the next block */
-    unsigned num_chan
+    auto num_chan
         = extract_value<uint32_t>(t, ACQ_CORE_ACQ_CHAN_CTL_NUM_CHAN_MASK);
     add_general(
         "WHICH", extract_value<uint32_t>(t, ACQ_CORE_ACQ_CHAN_CTL_WHICH_MASK));
@@ -240,8 +240,8 @@ void Core::decode()
     memcpy(p, &regs.ch0_desc, sizeof p);
 
     for (unsigned i = 0; i < num_chan; i++) {
-        uint32_t desc = p[i * REGISTERS_PER_CHAN],
-                 adesc = p[i * REGISTERS_PER_CHAN + 1];
+        uint32_t desc = p[i * REGISTERS_PER_CHAN];
+        uint32_t adesc = p[i * REGISTERS_PER_CHAN + 1];
         add_channel("INT_WIDTH", i,
             extract_value<uint32_t>(desc, ACQ_CORE_CH0_DESC_INT_WIDTH_MASK));
         add_channel("NUM_COALESCE", i,
@@ -306,10 +306,10 @@ struct NoSamples : std::runtime_error {
 void Controller::get_internal_values()
 {
     uint32_t channel_desc
-        = bar4_read(&bars, addr + ACQ_CORE_CH0_DESC + 8 * channel);
-    uint32_t num_coalesce = extract_value<uint32_t>(
+        = bar4_read(&bars, addr + ACQ_CORE_CH0_DESC + (8 * channel));
+    auto num_coalesce = extract_value<uint32_t>(
         channel_desc, ACQ_CORE_CH0_DESC_NUM_COALESCE_MASK);
-    uint32_t int_width = extract_value<uint32_t>(
+    auto int_width = extract_value<uint32_t>(
         channel_desc, ACQ_CORE_CH0_DESC_INT_WIDTH_MASK);
 
     /* int_width is in bits, so needs to be converted to bytes */
@@ -322,7 +322,7 @@ void Controller::get_internal_values()
         : 1;
 
     uint32_t channel_atom_desc
-        = bar4_read(&bars, addr + ACQ_CORE_CH0_ATOM_DESC + 8 * channel);
+        = bar4_read(&bars, addr + ACQ_CORE_CH0_ATOM_DESC + (8 * channel));
     channel_atom_width = extract_value<uint32_t>(
         channel_atom_desc, ACQ_CORE_CH0_ATOM_DESC_ATOM_WIDTH_MASK);
     channel_num_atoms = extract_value<uint32_t>(
@@ -347,15 +347,13 @@ void Controller::encode_params()
         if (value == 0) {
             if (can_be_zero)
                 return 0;
-            else
-                return alignment;
+            return alignment;
         }
 
         unsigned extra = value % alignment;
         if (extra)
             return value + (alignment - extra);
-        else
-            return value;
+        return value;
     };
 
     if (post_samples + pre_samples == 0)
@@ -387,7 +385,7 @@ void Controller::encode_params()
             { "data", { false, true, false, false } },
             { "software", { false, false, true, false } },
         });
-    auto &trigger_setting = trigger_types.at(trigger_type);
+    const auto &trigger_setting = trigger_types.at(trigger_type);
     insert_bit(regs.ctl, trigger_setting[0], ACQ_CORE_CTL_FSM_ACQ_NOW);
     insert_bit(regs.trig_cfg, trigger_setting[1], ACQ_CORE_TRIG_CFG_HW_TRIG_EN);
     insert_bit(regs.trig_cfg, trigger_setting[2], ACQ_CORE_TRIG_CFG_SW_TRIG_EN);
@@ -475,8 +473,8 @@ template <class Data> std::vector<Data> Controller::get_result()
     m_step = acq_step::stop;
 
     /* total number of elements (samples*atoms) */
-    size_t total_samples = acq_pre_samples + acq_post_samples,
-           elements = total_samples * channel_num_atoms;
+    size_t total_samples = acq_pre_samples + acq_post_samples;
+    size_t elements = total_samples * channel_num_atoms;
     size_t total_bytes = elements * (channel_atom_width / 8);
 
     /* this is an identity, just want to be sure */
@@ -520,8 +518,8 @@ template <class Data> std::vector<Data> Controller::get_result()
         = [this](ssize_t v) -> ssize_t { return v / sample_size; };
     auto samples2bytes
         = [this](ssize_t v) -> ssize_t { return v * sample_size; };
-    const ssize_t max_bytes = ram_end_addr - ram_start_addr,
-                  max_samples = bytes2samples(max_bytes);
+    const ssize_t max_bytes = ram_end_addr - ram_start_addr;
+    const ssize_t max_samples = bytes2samples(max_bytes);
     /* in order to simplify working with the acquisition circular buffer, think
      * first in terms of indexes into a circular buffer */
     const ssize_t trigger_index = bytes2samples(trigger_pos - ram_start_addr);
@@ -634,7 +632,7 @@ template <typename T> void Controller::print_csv(FILE *f, std::vector<T> &res)
         for (unsigned j = 0; j < channel_num_atoms; j++) {
             char tmp[32];
             auto r = std::to_chars(
-                tmp, tmp + sizeof tmp, res[i * channel_num_atoms + j]);
+                tmp, tmp + sizeof tmp, res[(i * channel_num_atoms) + j]);
             *r.ptr = '\0';
             fputs(tmp, f);
             fputc(',', f);

--- a/modules/afc_timing.cc
+++ b/modules/afc_timing.cc
@@ -134,7 +134,7 @@ void Core::decode()
     add_general("ALIVE", regs.alive);
 
     size_t i = 0;
-    for (auto clockp: {&regs.rtm_clock, &regs.afc_clock}) {
+    for (auto *clockp: {&regs.rtm_clock, &regs.afc_clock}) {
         add_channel("RFREQ_HI", i, clockp->rfreq_hi);
         add_channel("RFREQ_LO", i, clockp->rfreq_lo);
         add_channel("N1", i, extract_value<uint8_t>(clockp->n1_hs_div, TIMING_RTM_N1_MASK));

--- a/modules/afc_timing.cc
+++ b/modules/afc_timing.cc
@@ -164,7 +164,7 @@ void Core::decode()
     add_general("ALIVE", regs.alive);
 
     size_t i = 0;
-    for (auto clockp : { &regs.rtm_clock, &regs.afc_clock }) {
+    for (auto *clockp : { &regs.rtm_clock, &regs.afc_clock }) {
         add_channel("RFREQ_HI", i, clockp->rfreq_hi);
         add_channel("RFREQ_LO", i, clockp->rfreq_lo);
         add_channel("N1", i,
@@ -200,8 +200,8 @@ void Core::decode()
         add_channel("CH_ITL", i, rf_get_bit(*pt, TIMING_AMC0_ITL));
 
         auto ch_src = rf_extract_value(*pt, TIMING_AMC0_SRC_MASK);
-        assert(std::get<int32_t>(ch_src.value)
-            < (ssize_t)Controller::sources_list.size());
+        assert(std::cmp_less(std::get<int32_t>(ch_src.value)
+            ,Controller::sources_list.size());
         add_channel("CH_SRC", i, ch_src);
 
         add_channel("CH_DIR", i, rf_get_bit(*pt, TIMING_AMC0_DIR));

--- a/modules/fofb_processing.cc
+++ b/modules/fofb_processing.cc
@@ -91,17 +91,16 @@ void Core::read_monitors()
     for (unsigned i = 0; i < *number_of_channels; i++)
         get_register(WB_FOFB_PROCESSING_REGS_CH
             + WB_FOFB_PROCESSING_REGS_CH_SP_DECIM_DATA
-            + i * WB_FOFB_PROCESSING_REGS_CH_SIZE);
+            + (i * WB_FOFB_PROCESSING_REGS_CH_SIZE));
 }
 
 void Core::decode()
 {
-    uint32_t fixed_point_gain
+    auto fixed_point_gain
         = extract_value<uint32_t>(regs.fixed_point_pos.accs_gains,
             WB_FOFB_PROCESSING_REGS_FIXED_POINT_POS_ACCS_GAINS_VAL_MASK);
-    uint32_t fixed_point_coeff
-        = extract_value<uint32_t>(regs.fixed_point_pos.coeff,
-            WB_FOFB_PROCESSING_REGS_FIXED_POINT_POS_COEFF_VAL_MASK);
+    auto fixed_point_coeff = extract_value<uint32_t>(regs.fixed_point_pos.coeff,
+        WB_FOFB_PROCESSING_REGS_FIXED_POINT_POS_COEFF_VAL_MASK);
     add_general("FIXED_POINT_POS_GAINS", fixed_point_gain);
     add_general("FIXED_POINT_POS_COEFF", fixed_point_coeff);
 
@@ -168,11 +167,11 @@ void Core::decode()
     }
 
     size_t u = 0;
-    std::generate(ref_orb_x.begin(), ref_orb_x.end(),
-        [&]() { return (int32_t)regs.sps_ram_bank[u++].data; });
+    std::ranges::generate(
+        ref_orb_x, [&]() { return (int32_t)regs.sps_ram_bank[u++].data; });
     u = MAX_BPMS; /* access the second half of the RAM bank */
-    std::generate(ref_orb_y.begin(), ref_orb_y.end(),
-        [&]() { return (int32_t)regs.sps_ram_bank[u++].data; });
+    std::ranges::generate(
+        ref_orb_y, [&]() { return (int32_t)regs.sps_ram_bank[u++].data; });
 }
 
 void Core::print(FILE *f, bool verbose) const
@@ -184,11 +183,11 @@ void Core::print(FILE *f, bool verbose) const
     if (verbose) {
         fputs("reference orbit x:\n", f);
         for (auto v : ref_orb_x)
-            fprintf(f, "%d ", (int)v);
+            fprintf(f, "%d ", v);
 
         fputs("\nreference orbit y:\n", f);
         for (auto v : ref_orb_y)
-            fprintf(f, "%d ", (int)v);
+            fprintf(f, "%d ", v);
         fputc('\n', f);
     }
 

--- a/modules/fofb_shaper_filt.cc
+++ b/modules/fofb_shaper_filt.cc
@@ -76,8 +76,8 @@ void Core::decode()
     for (unsigned i = 0; i < NUM_CHANNELS; i++) {
         for (unsigned j = 0; j < num_biquads; j++) {
             for (unsigned k = 0; k < COEFFS_PER_BIQUAD; k++) {
-                coefficients.values[i][k + COEFFS_PER_BIQUAD * j] =
-                    fixed2float(regs.ch[i].coeffs[k + TOTAL_PER_BIQUAD * j].val, fixed_point_coeff);
+                coefficients.values[i][k + (COEFFS_PER_BIQUAD * j)] =
+                    fixed2float(regs.ch[i].coeffs[k + (TOTAL_PER_BIQUAD * j)].val, fixed_point_coeff);
             }
         }
     }
@@ -128,8 +128,8 @@ void Controller::encode_params()
     for (unsigned i = 0; i < NUM_CHANNELS; i++) {
         for (unsigned j = 0; j < num_biquads; j++) {
             for (unsigned k = 0; k < COEFFS_PER_BIQUAD; k++) {
-                regs.ch[i].coeffs[k + TOTAL_PER_BIQUAD * j].val =
-                    float2fixed(coefficients.values[i][k + COEFFS_PER_BIQUAD * j], fixed_point_coeff);
+                regs.ch[i].coeffs[k + (TOTAL_PER_BIQUAD * j)].val =
+                    float2fixed(coefficients.values[i][k + (COEFFS_PER_BIQUAD * j)], fixed_point_coeff);
             }
         }
     }
@@ -143,7 +143,7 @@ void Controller::write_params()
         for (unsigned j = 0; j < num_biquads; j++) {
             bar4_write_v(
                 &bars,
-                addr + WB_FOFB_SHAPER_FILT_REGS_CH_COEFFS + i * sizeof(regs.ch[0]) + TOTAL_PER_BIQUAD * j * sizeof(uint32_t),
+                addr + WB_FOFB_SHAPER_FILT_REGS_CH_COEFFS + (i * sizeof(regs.ch[0])) + (TOTAL_PER_BIQUAD * j * sizeof(uint32_t)),
                 &regs.ch[i].coeffs[TOTAL_PER_BIQUAD * j].val,
                 COEFFS_PER_BIQUAD * sizeof(uint32_t));
         }

--- a/modules/fofb_shaper_filt.cc
+++ b/modules/fofb_shaper_filt.cc
@@ -74,9 +74,10 @@ void Core::decode()
     for (unsigned i = 0; i < NUM_CHANNELS; i++) {
         for (unsigned j = 0; j < num_biquads; j++) {
             for (unsigned k = 0; k < COEFFS_PER_BIQUAD; k++) {
-                coefficients.values[i][k + COEFFS_PER_BIQUAD * j] = fixed2float(
-                    regs.ch[i].coeffs[k + TOTAL_PER_BIQUAD * j].val,
-                    fixed_point_coeff);
+                coefficients.values[i][k + (COEFFS_PER_BIQUAD * j)]
+                    = fixed2float(
+                        regs.ch[i].coeffs[k + (TOTAL_PER_BIQUAD * j)].val,
+                        fixed_point_coeff);
             }
         }
     }
@@ -131,8 +132,8 @@ void Controller::encode_params()
     for (unsigned i = 0; i < NUM_CHANNELS; i++) {
         for (unsigned j = 0; j < num_biquads; j++) {
             for (unsigned k = 0; k < COEFFS_PER_BIQUAD; k++) {
-                regs.ch[i].coeffs[k + TOTAL_PER_BIQUAD * j].val = float2fixed(
-                    coefficients.values[i][k + COEFFS_PER_BIQUAD * j],
+                regs.ch[i].coeffs[k + (TOTAL_PER_BIQUAD * j)].val = float2fixed(
+                    coefficients.values[i][k + (COEFFS_PER_BIQUAD * j)],
                     fixed_point_coeff);
             }
         }
@@ -147,8 +148,8 @@ void Controller::write_params()
         for (unsigned j = 0; j < num_biquads; j++) {
             bar4_write_v(&bars,
                 addr + WB_FOFB_SHAPER_FILT_REGS_CH_COEFFS
-                    + i * sizeof(regs.ch[0])
-                    + TOTAL_PER_BIQUAD * j * sizeof(uint32_t),
+                    + (i * sizeof(regs.ch[0]))
+                    + (TOTAL_PER_BIQUAD * j * sizeof(uint32_t)),
                 &regs.ch[i].coeffs[TOTAL_PER_BIQUAD * j].val,
                 COEFFS_PER_BIQUAD * sizeof(uint32_t));
         }

--- a/modules/isla216p.cc
+++ b/modules/isla216p.cc
@@ -68,6 +68,7 @@ bool Controller::set_reg(uint8_t addr, uint8_t rdata, spi::Channel channel)
 
 bool Controller::set_defaults(spi::Channel)
 {
+    (void)this;
     return false;
 }
 

--- a/modules/isla216p.cc
+++ b/modules/isla216p.cc
@@ -70,6 +70,10 @@ bool Controller::set_reg(uint8_t addr, uint8_t rdata, spi::Channel channel)
         wdata, sizeof wdata, &rdata, sizeof rdata, channel.channel);
 }
 
-bool Controller::set_defaults(spi::Channel) { return false; }
+bool Controller::set_defaults(spi::Channel)
+{
+    (void)this;
+    return false;
+}
 
 } /* namespace isla216p */

--- a/modules/lamp.cc
+++ b/modules/lamp.cc
@@ -10,8 +10,8 @@ namespace lamp {
 #include "hw/wb_rtmlamp_ohwr_regs.h"
 
 namespace {
-    static constexpr unsigned NUM_CHAN = 12;
-    static constexpr unsigned TRIGGER_ENABLE_VERSION = 1;
+    constexpr unsigned NUM_CHAN = 12;
+    constexpr unsigned TRIGGER_ENABLE_VERSION = 1;
 
     constexpr unsigned LAMP_DEVID = 0xa1248bec;
     struct sdb_device_info ref_devinfo = {
@@ -88,7 +88,8 @@ Core::~Core() = default;
 
 void Core::decode()
 {
-    uint32_t t, *pt;
+    uint32_t t;
+    uint32_t *pt;
 
     /* add printer if this value ever gets flags;
      * this is being done for IOC compatibility */

--- a/modules/lamp.cc
+++ b/modules/lamp.cc
@@ -10,8 +10,8 @@ namespace lamp {
 #include "hw/wb_rtmlamp_ohwr_regs.h"
 
 namespace {
-    static constexpr unsigned NUM_CHAN = 12;
-    static constexpr unsigned TRIGGER_ENABLE_VERSION = 1;
+    constexpr unsigned NUM_CHAN = 12;
+    constexpr unsigned TRIGGER_ENABLE_VERSION = 1;
 
     constexpr unsigned LAMP_DEVID = 0xa1248bec;
     struct sdb_device_info ref_devinfo = {
@@ -102,7 +102,8 @@ Core::~Core() = default;
 
 void Core::decode()
 {
-    uint32_t t, *pt;
+    uint32_t t;
+    uint32_t *pt;
 
     /* add printer if this value ever gets flags;
      * this is being done for IOC compatibility */

--- a/modules/pos_calc.cc
+++ b/modules/pos_calc.cc
@@ -51,17 +51,17 @@ struct SyncMaskRates {
     } tbt, facq, monit;
     SyncMaskRates(struct pos_calc &regs):
         tbt{
-            &regs.tbt_tag,
-            &regs.tbt_data_mask_ctl,
-            &regs.tbt_data_mask_samples,},
+            .tag = &regs.tbt_tag,
+            .data_mask_ctl = &regs.tbt_data_mask_ctl,
+            .data_mask_samples = &regs.tbt_data_mask_samples,},
         facq{
-            &regs.monit1_tag,
-            &regs.monit1_data_mask_ctl,
-            &regs.monit1_data_mask_samples,},
+            .tag = &regs.monit1_tag,
+            .data_mask_ctl = &regs.monit1_data_mask_ctl,
+            .data_mask_samples = &regs.monit1_data_mask_samples,},
         monit{
-            &regs.monit_tag,
-            &regs.monit_data_mask_ctl,
-            &regs.monit_data_mask_samples,}
+            .tag = &regs.monit_tag,
+            .data_mask_ctl = &regs.monit_data_mask_ctl,
+            .data_mask_samples = &regs.monit_data_mask_samples,}
     {
     }
 };

--- a/modules/pos_calc.cc
+++ b/modules/pos_calc.cc
@@ -55,17 +55,17 @@ struct SyncMaskRates {
     } tbt, facq, monit;
     SyncMaskRates(struct pos_calc &regs):
         tbt{
-            &regs.tbt_tag,
-            &regs.tbt_data_mask_ctl,
-            &regs.tbt_data_mask_samples,},
+            .tag=&regs.tbt_tag,
+            .data_mask_ctl=&regs.tbt_data_mask_ctl,
+            .data_mask_samples=&regs.tbt_data_mask_samples,},
         facq{
-            &regs.monit1_tag,
-            &regs.monit1_data_mask_ctl,
-            &regs.monit1_data_mask_samples,},
+            .tag=&regs.monit1_tag,
+            .data_mask_ctl=&regs.monit1_data_mask_ctl,
+            .data_mask_samples=&regs.monit1_data_mask_samples,},
         monit{
-            &regs.monit_tag,
-            &regs.monit_data_mask_ctl,
-            &regs.monit_data_mask_samples,}
+            .tag=&regs.monit_tag,
+            .data_mask_ctl=&regs.monit_data_mask_ctl,
+            .data_mask_samples=&regs.monit_data_mask_samples,}
     {
     }
 };

--- a/modules/si57x_ctrl.cc
+++ b/modules/si57x_ctrl.cc
@@ -71,8 +71,7 @@ Controller::Controller(struct pcie_bars &bars, double fstartup):
     RegisterDecoderController(bars, ref_devinfo, &dec),
     CONSTRUCTOR_REGS(struct wb_si57x_ctrl_regs),
     dec(bars),
-    fstartup(fstartup),
-    fxtal(0)
+    fstartup(fstartup)
 {
     set_read_dest(regs);
 }
@@ -147,10 +146,7 @@ bool Controller::apply_config()
     write_general("APPLY_CFG", 1);
     write_params();
 
-    if (still_busy() || !dec.get_general_data<int32_t>("CFG_IN_SYNC"))
-        return false;
-
-    return true;
+    return !still_busy() && dec.get_general_data<int32_t>("CFG_IN_SYNC");
 }
 
 bool Controller::set_freq(double freq)

--- a/modules/si57x_ctrl.cc
+++ b/modules/si57x_ctrl.cc
@@ -96,7 +96,7 @@ Controller::Controller(struct pcie_bars &bars, double fstartup)
     , CONSTRUCTOR_REGS(struct wb_si57x_ctrl_regs)
     , dec(bars)
     , fstartup(fstartup)
-    , fxtal(0)
+
 {
     set_read_dest(regs);
 }
@@ -171,10 +171,7 @@ bool Controller::apply_config()
     write_general("APPLY_CFG", 1);
     write_params();
 
-    if (still_busy() || !dec.get_general_data<int32_t>("CFG_IN_SYNC"))
-        return false;
-
-    return true;
+    return !(still_busy() || !dec.get_general_data<int32_t>("CFG_IN_SYNC"));
 }
 
 bool Controller::set_freq(double freq)

--- a/modules/spi.cc
+++ b/modules/spi.cc
@@ -104,7 +104,7 @@ void Controller::set_devinfo_callback()
 
 int32_t Controller::get_divider(int32_t sys_freq, int32_t spi_freq)
 {
-    return sys_freq / (2 * spi_freq) - 1;
+    return (sys_freq / (2 * spi_freq)) - 1;
 }
 
 void Controller::set_defaults()

--- a/modules/spi.cc
+++ b/modules/spi.cc
@@ -106,7 +106,7 @@ void Controller::set_devinfo_callback() { set_defaults(); }
 
 int32_t Controller::get_divider(int32_t sys_freq, int32_t spi_freq)
 {
-    return sys_freq / (2 * spi_freq) - 1;
+    return (sys_freq / (2 * spi_freq)) - 1;
 }
 
 void Controller::set_defaults()

--- a/util/controllers.h
+++ b/util/controllers.h
@@ -53,7 +53,7 @@ class RegisterDecoderController: public RegisterController {
         RegisterController::set_devinfo(devinfo);
     }
 
-    virtual void encode_params() override { }
+    void encode_params() override { }
 
     void write_general(const char *name, decoders::data_type value)
     {

--- a/util/controllers.h
+++ b/util/controllers.h
@@ -51,7 +51,7 @@ public:
         RegisterController::set_devinfo(devinfo);
     }
 
-    virtual void encode_params() override { }
+    void encode_params() override { }
 
     void write_general(const char *name, decoders::data_type value)
     {

--- a/util/decoders.cc
+++ b/util/decoders.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <stdexcept>
+#include <utility>
 
 #include <tsl/ordered_map.h>
 
@@ -38,7 +39,7 @@ RegisterDecoder::RegisterDecoder(
 
     RegisterDecoderBase(bars, ref_devinfo),
     pvt(new RegisterDecoderPrivate()),
-    printers(printers)
+    printers(std::move(std::move(printers)))
 {
 }
 RegisterDecoder::~RegisterDecoder() = default;
@@ -50,9 +51,8 @@ bool RegisterDecoder::is_boolean_value(const char *name) const
     if (printer_it != printers.end()) {
         auto type = printer_it->second.get_type();
         return type == PrinterType::boolean || type == PrinterType::progress || type == PrinterType::enable;
-    } else {
-        return false;
     }
+    return false;
 }
 
 int32_t RegisterDecoder::try_boolean_value(const char *name, int32_t value) const
@@ -95,7 +95,7 @@ void RegisterDecoder::add_channel_double(const char *name, unsigned pos, double 
     add_data_internal(name, pos, value);
 }
 
-size_t RegisterDecoder::register2offset(uint32_t *reg)
+size_t RegisterDecoder::register2offset(const uint32_t *reg)
 {
     auto rdp = (uintptr_t)read_dest;
     auto rp = (uintptr_t)reg;

--- a/util/decoders.cc
+++ b/util/decoders.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <stdexcept>
+#include <utility>
 
 #include <tsl/ordered_map.h>
 
@@ -39,7 +40,7 @@ RegisterDecoder::RegisterDecoder(struct pcie_bars &bars,
 
     RegisterDecoderBase(bars, ref_devinfo)
     , pvt(new RegisterDecoderPrivate())
-    , printers(printers)
+    , printers(std::move(printers))
 {
 }
 RegisterDecoder::~RegisterDecoder() = default;
@@ -52,9 +53,8 @@ bool RegisterDecoder::is_boolean_value(const char *name) const
         auto type = printer_it->second.get_type();
         return type == PrinterType::boolean || type == PrinterType::progress
             || type == PrinterType::enable;
-    } else {
-        return false;
     }
+    return false;
 }
 
 int32_t RegisterDecoder::try_boolean_value(
@@ -102,7 +102,7 @@ void RegisterDecoder::add_channel_double(
     add_data_internal(name, pos, value);
 }
 
-size_t RegisterDecoder::register2offset(uint32_t *reg)
+size_t RegisterDecoder::register2offset(const uint32_t *reg)
 {
     auto rdp = (uintptr_t)read_dest;
     auto rp = (uintptr_t)reg;

--- a/util/decoders.h
+++ b/util/decoders.h
@@ -46,6 +46,7 @@ class RegisterDecoderBase {
      * initializer */
     bool check_devinfo = false;
 
+    [[nodiscard]]
     bool match_devinfo(const struct sdb_device_info &) const;
 
   protected:
@@ -105,7 +106,7 @@ class RegisterDecoder: public RegisterDecoderBase {
 
     void rf_add_data_internal(const char *, decoders::data_key::second_type, RegisterField);
 
-    size_t register2offset(uint32_t *);
+    size_t register2offset(const uint32_t *);
     uint32_t *offset2register(size_t, void *);
 
     void write_internal(const char *, std::optional<unsigned>, decoders::data_type, void *);
@@ -143,15 +144,15 @@ class RegisterDecoder: public RegisterDecoderBase {
         return rf_extract_value(value, UINT32_MAX, is_signed);
     }
     /** set RegisterField metadata for conversion to and from fixed point */
-    RegisterField rf_fixed2float(RegisterField, unsigned);
+    static RegisterField rf_fixed2float(RegisterField, unsigned);
 
     /** add_general() that takes a RegisterField */
-    inline void add_general(const char *name, RegisterField rf)
+    void add_general(const char *name, RegisterField rf)
     {
         rf_add_data_internal(name, std::nullopt, rf);
     }
     /** add_channel() that takes a RegisterField */
-    inline void add_channel(const char *name, unsigned pos, RegisterField rf)
+    void add_channel(const char *name, unsigned pos, RegisterField rf)
     {
         rf_add_data_internal(name, pos, rf);
     }
@@ -188,11 +189,11 @@ class RegisterDecoder: public RegisterDecoderBase {
 
     std::optional<unsigned> channel;
 
-    inline void write_general(const char *name, decoders::data_type value, void *dest)
+    void write_general(const char *name, decoders::data_type value, void *dest)
     {
         write_internal(name, std::nullopt, value, dest);
     }
-    inline void write_channel(const char *name, unsigned pos, decoders::data_type value, void *dest)
+    void write_channel(const char *name, unsigned pos, decoders::data_type value, void *dest)
     {
         write_internal(name, pos, value, dest);
     }

--- a/util/decoders.h
+++ b/util/decoders.h
@@ -15,7 +15,7 @@
 
 #include "sdb-defs.h"
 
-#define LNLS_VENDORID 0x1000000000001215
+enum { LNLS_VENDORID = 0x1000000000001215 };
 
 struct RegisterDecoderPrivate;
 class Printer;
@@ -46,7 +46,7 @@ class RegisterDecoderBase {
      * initializer */
     bool check_devinfo = false;
 
-    bool match_devinfo(const struct sdb_device_info &) const;
+    [[nodiscard]] bool match_devinfo(const struct sdb_device_info &) const;
 
 protected:
     size_t read_size;
@@ -106,7 +106,7 @@ class RegisterDecoder : public RegisterDecoderBase {
     void rf_add_data_internal(
         const char *, decoders::data_key::second_type, RegisterField);
 
-    size_t register2offset(uint32_t *);
+    size_t register2offset(const uint32_t *);
     uint32_t *offset2register(size_t, void *);
 
     void write_internal(
@@ -146,15 +146,15 @@ protected:
         return rf_extract_value(value, UINT32_MAX, is_signed);
     }
     /** set RegisterField metadata for conversion to and from fixed point */
-    RegisterField rf_fixed2float(RegisterField, unsigned);
+    static RegisterField rf_fixed2float(RegisterField, unsigned);
 
     /** add_general() that takes a RegisterField */
-    inline void add_general(const char *name, RegisterField rf)
+    void add_general(const char *name, RegisterField rf)
     {
         rf_add_data_internal(name, std::nullopt, rf);
     }
     /** add_channel() that takes a RegisterField */
-    inline void add_channel(const char *name, unsigned pos, RegisterField rf)
+    void add_channel(const char *name, unsigned pos, RegisterField rf)
     {
         rf_add_data_internal(name, pos, rf);
     }
@@ -191,12 +191,11 @@ public:
 
     std::optional<unsigned> channel;
 
-    inline void write_general(
-        const char *name, decoders::data_type value, void *dest)
+    void write_general(const char *name, decoders::data_type value, void *dest)
     {
         write_internal(name, std::nullopt, value, dest);
     }
-    inline void write_channel(
+    void write_channel(
         const char *name, unsigned pos, decoders::data_type value, void *dest)
     {
         write_internal(name, pos, value, dest);

--- a/util/pcie-defs.h
+++ b/util/pcie-defs.h
@@ -6,8 +6,8 @@
 #define PCIE_STRUCT_H
 
 #include <pthread.h>
-#include <stdint.h>
-#include <stdio.h>
+#include <cstdint>
+#include <cstdio>
 #include <sys/types.h>
 
 enum bar_lock {

--- a/util/pcie-open.cc
+++ b/util/pcie-open.cc
@@ -3,9 +3,9 @@
 #include <fstream>
 #include <string>
 
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
-#include <string.h>
+#include <cstring>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -141,7 +141,7 @@ void dev_open_serial(struct pcie_bars &bars, const char *dev_file)
     xfail(tcsetattr(fd, TCSAFLUSH, &term));
 
     bars.fserport = fdopen(fd, "r+");
-    setvbuf(bars.fserport, NULL, _IOLBF, 0);
+    setvbuf(bars.fserport, nullptr, _IOLBF, 0);
 
     configure_mutexes(bars);
 }

--- a/util/pcie-open.cc
+++ b/util/pcie-open.cc
@@ -3,9 +3,9 @@
 #include <fstream>
 #include <string>
 
-#include <errno.h>
+#include <cerrno>
+#include <cstring>
 #include <fcntl.h>
-#include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -158,7 +158,7 @@ void dev_open_serial(struct pcie_bars &bars, const char *dev_file)
     xfail(tcsetattr(fd, TCSAFLUSH, &term));
 
     bars.fserport = fdopen(fd, "r+");
-    setvbuf(bars.fserport, NULL, _IOLBF, 0);
+    setvbuf(bars.fserport, nullptr, _IOLBF, 0);
 
     configure_mutexes(bars);
 }

--- a/util/pcie.c
+++ b/util/pcie.c
@@ -31,19 +31,21 @@
 
 /* PCIe SDRAM Address Page number and offset extractor */
 #define PCIE_ADDR_SDRAM_PG_OFFS(addr)                                          \
-    ((addr & PCIE_SDRAM_PG_MASK) >> PCIE_SDRAM_PG_SHIFT)
+    (((addr) & PCIE_SDRAM_PG_MASK) >> PCIE_SDRAM_PG_SHIFT)
 #define PCIE_ADDR_SDRAM_PG(addr)                                               \
-    ((addr & ~PCIE_SDRAM_PG_MASK) >> PCIE_SDRAM_PG_MAX)
+    (((addr) & ~PCIE_SDRAM_PG_MASK) >> PCIE_SDRAM_PG_MAX)
 
 /* PCIe WB Address Page number and offset extractor */
 #define PCIE_ADDR_WB_PG_OFFS(addr)                                             \
-    ((addr & PCIE_WB_PG_MASK) >> PCIE_WB_PG_SHIFT)
-#define PCIE_ADDR_WB_PG(addr) ((addr & ~PCIE_WB_PG_MASK) >> PCIE_WB_PG_MAX)
+    (((addr) & PCIE_WB_PG_MASK) >> PCIE_WB_PG_SHIFT)
+#define PCIE_ADDR_WB_PG(addr) (((addr) & ~PCIE_WB_PG_MASK) >> PCIE_WB_PG_MAX)
 
-#define WB_QWORD_ACC 3 /* 64-bit addressing */
-#define WB_DWORD_ACC 2 /* 32-bit addressing */
-#define WB_WORD_ACC 1 /* 16-bit addressing */
-#define WB_BYTE_ACC 0 /* 8-bit addressing */
+enum {
+    WB_QWORD_ACC = 3, /* 64-bit addressing */
+    WB_DWORD_ACC = 2, /* 32-bit addressing */
+    WB_WORD_ACC = 1, /* 16-bit addressing */
+    WB_BYTE_ACC = 0 /* 8-bit addressing */
+};
 
 /* FPGA PCIe registers. These are inside bar0 and must match
  * the FPGA firmware */
@@ -65,17 +67,19 @@
 #define PCIE_CFG_REG_DMA_STA (8 << WB_DWORD_ACC)
 
 /* Relevant values for DMA registers */
-#define PCIE_CFG_DMA_CTRL_AINC (1 << 15)
-#define PCIE_CFG_DMA_CTRL_BAR_SHIFT 16
-#define PCIE_CFG_DMA_CTRL_LAST (1 << 24)
-#define PCIE_CFG_DMA_CTRL_VALID (1 << 25)
-#define PCIE_CFG_DMA_STA_DONE (1 << 0)
-#define PCIE_CFG_DMA_STA_TIMEOUT (1 << 4)
+enum {
+    PCIE_CFG_DMA_CTRL_AINC = (1 << 15),
+    PCIE_CFG_DMA_CTRL_BAR_SHIFT = 16,
+    PCIE_CFG_DMA_CTRL_LAST = (1 << 24),
+    PCIE_CFG_DMA_CTRL_VALID = (1 << 25),
+    PCIE_CFG_DMA_STA_DONE = (1 << 0),
+    PCIE_CFG_DMA_STA_TIMEOUT = (1 << 4)
+};
 
 /* Other registers and values */
 #define PCIE_CFG_REG_TX_CTRL (30 << WB_DWORD_ACC)
 #define PCIE_CFG_REG_EB_STACON (36 << WB_DWORD_ACC)
-#define PCIE_CFG_TX_CTRL_CHANNEL_RST 0x0A
+enum { PCIE_CFG_TX_CTRL_CHANNEL_RST = 0x0A };
 
 static void bar_generic_read_v(struct pcie_bars *bars, size_t addr, void *dest,
     size_t n, uint32_t (*fn)(struct pcie_bars *bars, size_t addr))
@@ -144,7 +148,8 @@ void bar2_read_v(struct pcie_bars *bars, size_t addr, void *dest, size_t n)
         size_t i = 0;
 
 #ifdef USE_SSE41
-        const size_t alignment = 64, read_size = 1024;
+        const size_t alignment = 64;
+        const size_t read_size = 1024;
 
         size_t head = addr_now % alignment;
         head = head ? alignment - head : 0;
@@ -152,11 +157,14 @@ void bar2_read_v(struct pcie_bars *bars, size_t addr, void *dest, size_t n)
             destp[i] = *bar2_get_u32p_small(bars, addr_now, i);
 
         for (; i + (read_size - 1) < to_read / 4; i += read_size) {
-            __m128i a, b, c, d;
+            __m128i a;
+            __m128i b;
+            __m128i c;
+            __m128i d;
 
             _mm_mfence();
             for (size_t j = 0; j < 64; j++) {
-                size_t base = i + j * 16;
+                size_t base = i + (j * 16);
                 a = _mm_stream_load_si128(
                     (__m128i *)bar2_get_u32p_small(bars, addr_now, base));
                 b = _mm_stream_load_si128(
@@ -181,7 +189,7 @@ void bar2_read_v(struct pcie_bars *bars, size_t addr, void *dest, size_t n)
                 c = _mm_load_si128(scratch + base + 2);
                 d = _mm_load_si128(scratch + base + 3);
 
-                base = i + j * 16;
+                base = i + (j * 16);
                 _mm_stream_si128((__m128i *)(destp + base), a);
                 _mm_stream_si128((__m128i *)(destp + base + 4), b);
                 _mm_stream_si128((__m128i *)(destp + base + 8), c);
@@ -195,7 +203,7 @@ void bar2_read_v(struct pcie_bars *bars, size_t addr, void *dest, size_t n)
         n -= to_read;
         addr += to_read;
         assert((to_read & 0x3) == 0);
-        destp = destp + to_read / 4;
+        destp = destp + (to_read / 4);
     }
 
     pthread_mutex_unlock(&bars->locks[BAR2]);
@@ -311,7 +319,7 @@ static ssize_t uart_read_cmd(
                 char *data = line + 1;
                 for (ssize_t i = 0;
                     i < ((ans_str_size - 2) / 8) && i < num_words; i++) {
-                    int elements = sscanf(data + i * 8, "%8x", dest_u32);
+                    int elements = sscanf(data + (i * 8), "%8x", dest_u32);
                     dest_u32 += 1;
                     words_read += 1;
                     assert(elements == 1);
@@ -359,7 +367,7 @@ void bar4_read_v(struct pcie_bars *bars, size_t addr, void *dest, size_t n)
             ssize_t words_read = uart_read_cmd(bars, addr, dest, words_to_read);
             assert(words_read == words_to_read);
             addr += words_to_read * 4;
-            dest = (unsigned char *)dest + words_to_read * 4;
+            dest = (unsigned char *)dest + (words_to_read * 4);
         }
 
         goto unlock;

--- a/util/printer.cc
+++ b/util/printer.cc
@@ -1,5 +1,6 @@
 #include <charconv>
 #include <string>
+#include <utility>
 
 #include "printer.h"
 
@@ -28,12 +29,12 @@ Printer::Printer(const char *name, const char *description, PrinterType type):
 }
 
 Printer::Printer(const char *name, const char *description, printing_function custom_fn):
-    type(PrinterType::internal_custom_function), name(name), description(description), custom_fn(custom_fn)
+    type(PrinterType::internal_custom_function), name(name), description(description), custom_fn(std::move(custom_fn))
 {
 }
 
 Printer::Printer(const char *name, const char *description, const char *not_truth, const char *truth):
-    type(PrinterType::boolean), name(name), description(description), boolean_names{truth, not_truth}
+    type(PrinterType::boolean), name(name), description(description), boolean_names{.truth=truth, .not_truth=not_truth}
 {
 }
 

--- a/util/printer.cc
+++ b/util/printer.cc
@@ -1,5 +1,6 @@
 #include <charconv>
 #include <string>
+#include <utility>
 
 #include "printer.h"
 
@@ -35,7 +36,7 @@ Printer::Printer(
     : type(PrinterType::internal_custom_function)
     , name(name)
     , description(description)
-    , custom_fn(custom_fn)
+    , custom_fn(std::move(custom_fn))
 {
 }
 
@@ -44,7 +45,7 @@ Printer::Printer(const char *name, const char *description,
     : type(PrinterType::boolean)
     , name(name)
     , description(description)
-    , boolean_names { truth, not_truth }
+    , boolean_names { .truth = truth, .not_truth = not_truth }
 {
 }
 

--- a/util/printer.h
+++ b/util/printer.h
@@ -19,7 +19,7 @@ enum class PrinterType {
     internal_custom_function,
 };
 
-typedef std::function<void(FILE *, bool, uint32_t)> printing_function;
+using printing_function = std::function<void (FILE *, bool, uint32_t)>;
 
 class Printer {
     PrinterType type;
@@ -37,6 +37,7 @@ class Printer {
     Printer(const char *name, const char *description, printing_function custom_fn);
     Printer(const char *name, const char *description, const char *not_truth, const char *truth);
 
+    [[nodiscard]]
     PrinterType get_type() const;
 
     template<typename T>

--- a/util/printer.h
+++ b/util/printer.h
@@ -19,7 +19,7 @@ enum class PrinterType {
     internal_custom_function,
 };
 
-typedef std::function<void(FILE *, bool, uint32_t)> printing_function;
+using printing_function = std::function<void(FILE *, bool, uint32_t)>;
 
 class Printer {
     PrinterType type;
@@ -39,7 +39,7 @@ public:
     Printer(const char *name, const char *description, const char *not_truth,
         const char *truth);
 
-    PrinterType get_type() const;
+    [[nodiscard]] PrinterType get_type() const;
 
     template <typename T> void print(FILE *, bool, unsigned, T) const;
 };

--- a/util/sdb-defs.h
+++ b/util/sdb-defs.h
@@ -21,6 +21,6 @@ struct sdb_synthesis_info {
     char user_name[16];
 };
 
-typedef std::function<bool(const struct sdb_device_info &)> device_match_fn;
+using device_match_fn = std::function<bool (const struct sdb_device_info &)>;
 
 #endif

--- a/util/sdb-defs.h
+++ b/util/sdb-defs.h
@@ -21,6 +21,6 @@ struct sdb_synthesis_info {
     char user_name[16];
 };
 
-typedef std::function<bool(const struct sdb_device_info &)> device_match_fn;
+using device_match_fn = std::function<bool(const struct sdb_device_info &)>;
 
 #endif

--- a/util/sdb.cc
+++ b/util/sdb.cc
@@ -110,7 +110,7 @@ std::vector<struct sdb_synthesis_info> get_synthesis_info(struct pcie_bars *bars
         struct sdb_product *p = &d->sdb_component.product;
         if (p->record_type != sdb_type_synthesis) continue;
 
-        auto s = (struct sdb_synthesis *)(void *)d;
+        auto s = reinterpret_cast<struct sdb_synthesis *>(d);
 
         struct sdb_synthesis_info syninfo;
 

--- a/util/sdb.cc
+++ b/util/sdb.cc
@@ -1,9 +1,9 @@
 #include <cassert>
 #include <limits>
 
+#include <climits>
+#include <cstdint>
 #include <endian.h>
-#include <limits.h>
-#include <stdint.h>
 
 extern "C" {
 /* library uses "this" as a struct member name */
@@ -65,14 +65,14 @@ static void print_sdb(const struct sdb_device_info &devinfo,
     fprintf(stdout,
         "%sname %19s id %08jx vendor %016jx version %04x.%04x addr %08jx\n",
         /* indent entries according to fs.depth */
-        indentation + indent * (max_indent - depth), product->name,
+        indentation + (indent * (max_indent - depth)), product->name,
         (uintmax_t)devinfo.device_id, (uintmax_t)devinfo.vendor_id,
         (unsigned)devinfo.abi_ver_major, (unsigned)devinfo.abi_ver_minor,
         (uintmax_t)devinfo.start_addr);
 }
 
 std::optional<struct sdb_device_info> read_sdb(
-    struct pcie_bars *bars, device_match_fn device_match, unsigned pos)
+    struct pcie_bars *bars, const device_match_fn &device_match, unsigned pos)
 {
     struct sdbfs fs = sdbfs_init(bars);
     defer _(nullptr, [&fs](...) { sdbfs_dev_destroy(&fs); });
@@ -96,8 +96,7 @@ std::optional<struct sdb_device_info> read_sdb(
             if (device_match(devinfo)) {
                 if (pos == 0)
                     return devinfo;
-                else
-                    pos--;
+                pos--;
             }
         } else {
             print_sdb(devinfo, p, fs, min_depth);
@@ -120,7 +119,7 @@ std::vector<struct sdb_synthesis_info> get_synthesis_info(
         if (p->record_type != sdb_type_synthesis)
             continue;
 
-        auto s = reinterpret_cast<struct sdb_synthesis *>(d);
+        auto *s = reinterpret_cast<struct sdb_synthesis *>(d);
 
         struct sdb_synthesis_info syninfo;
 
@@ -140,10 +139,10 @@ std::vector<struct sdb_synthesis_info> get_synthesis_info(
 
         copy_string(syninfo.name, s->syn_name);
 
-        static_assert(sizeof syninfo.commit == sizeof s->commit_id * 2 + 1);
+        static_assert(sizeof syninfo.commit == (sizeof s->commit_id * 2) + 1);
         /* sprintf nul-terminates it automatically for us */
         for (size_t i = 0; i < sizeof s->commit_id; i++)
-            sprintf(syninfo.commit + i * 2, "%02x", s->commit_id[i]);
+            sprintf(syninfo.commit + (i * 2), "%02x", s->commit_id[i]);
 
         copy_string(syninfo.tool_name, s->tool_name);
         syninfo.tool_version = ntohl(s->tool_version);

--- a/util/sdb.cc
+++ b/util/sdb.cc
@@ -120,7 +120,7 @@ std::vector<struct sdb_synthesis_info> get_synthesis_info(
         if (p->record_type != sdb_type_synthesis)
             continue;
 
-        auto s = (struct sdb_synthesis *)(void *)d;
+        auto s = reinterpret_cast<struct sdb_synthesis *>(d);
 
         struct sdb_synthesis_info syninfo;
 

--- a/util/si57x_util.cc
+++ b/util/si57x_util.cc
@@ -50,7 +50,8 @@ bool si57x_parameters::calc_fxtal()
 
 bool si57x_parameters::set_freq(double freq)
 {
-    uint32_t n1_best, hs_div_best;
+    uint32_t n1_best;
+    uint32_t hs_div_best;
     uint64_t rfreq_best;
     double freq_err_best = 1e9;
     bool best_is_set = false;
@@ -84,7 +85,7 @@ bool si57x_parameters::set_freq(double freq)
     return true;
 }
 
-double si57x_parameters::get_freq()
+double si57x_parameters::get_freq() const
 {
     return fxtal * hw2val_rfreq(rfreq) / (hw2val_hs_div(hs_div) * hw2val_n1(n1));
 }

--- a/util/si57x_util.cc
+++ b/util/si57x_util.cc
@@ -39,7 +39,8 @@ bool si57x_parameters::calc_fxtal()
 
 bool si57x_parameters::set_freq(double freq)
 {
-    uint32_t n1_best, hs_div_best;
+    uint32_t n1_best;
+    uint32_t hs_div_best;
     uint64_t rfreq_best;
     double freq_err_best = 1e9;
     bool best_is_set = false;
@@ -75,7 +76,7 @@ bool si57x_parameters::set_freq(double freq)
     return true;
 }
 
-double si57x_parameters::get_freq()
+double si57x_parameters::get_freq() const
 {
     return fxtal * hw2val_rfreq(rfreq)
         / (hw2val_hs_div(hs_div) * hw2val_n1(n1));

--- a/util/si57x_util.h
+++ b/util/si57x_util.h
@@ -27,7 +27,8 @@ struct si57x_parameters {
      * on failure. */
     bool set_freq(double);
     /** Get the output frequency, based on #fxtal, #rfreq, #n1 and #hs_div. */
-    double get_freq();
+    [[nodiscard]]
+    double get_freq() const;
 };
 
 #endif

--- a/util/si57x_util.h
+++ b/util/si57x_util.h
@@ -27,7 +27,7 @@ struct si57x_parameters {
      * on failure. */
     bool set_freq(double);
     /** Get the output frequency, based on #fxtal, #rfreq, #n1 and #hs_div. */
-    double get_freq();
+    [[nodiscard]] double get_freq() const;
 };
 
 #endif

--- a/util/tests/copy-test.cc
+++ b/util/tests/copy-test.cc
@@ -14,7 +14,7 @@ int main()
     defer _(nullptr, [&bars](...){dev_close(bars);});
 
     const size_t s = bars.sizes[1] / sizeof(uint32_t);
-    uint32_t *p = reinterpret_cast<uint32_t *>(const_cast<void *>(bars.bar2));
+    auto *p = reinterpret_cast<uint32_t *>(const_cast<void *>(bars.bar2));
     for (size_t i = 0; i < s; i++)
         p[i] = i;
 
@@ -34,7 +34,7 @@ int main()
                 (void *)((unsigned char *)bars.bar2 + bar_off),
                 (void *)((unsigned char *)dest + dest_off),
                 to_read);
-            if (memcmp((unsigned char *)bars.bar2 + bar_off, (unsigned char *)dest + dest_off, to_read)) {
+            if (memcmp((unsigned char *)bars.bar2 + bar_off, (unsigned char *)dest + dest_off, to_read) != 0) {
                 std::cerr << "memcmp failed" << std::endl;
                 exit(1);
             }
@@ -55,8 +55,8 @@ int main()
     }
 
     for (auto off: offs) {
-        bar2_read_v(&bars, off, dest, bars.sizes[1] * 2 + 128);
-        compare(off, 0, bars.sizes[1] * 2 + 128);
+        bar2_read_v(&bars, off, dest, (bars.sizes[1] * 2) + 128);
+        compare(off, 0, (bars.sizes[1] * 2) + 128);
     }
 
     free(dest);

--- a/util/tests/copy-test.cc
+++ b/util/tests/copy-test.cc
@@ -14,7 +14,7 @@ int main()
     defer _(nullptr, [&bars](...) { dev_close(bars); });
 
     const size_t s = bars.sizes[1] / sizeof(uint32_t);
-    uint32_t *p = reinterpret_cast<uint32_t *>(const_cast<void *>(bars.bar2));
+    auto *p = reinterpret_cast<uint32_t *>(const_cast<void *>(bars.bar2));
     for (size_t i = 0; i < s; i++)
         p[i] = i;
 
@@ -25,17 +25,18 @@ int main()
         = [&bars, dest, dest_s, s](size_t bar_off, size_t dest_off, size_t n) {
               while (n) {
                   size_t to_read;
-                  if (n < s * 4 - bar_off) {
+                  if (n < (s * 4) - bar_off) {
                       to_read = n;
                   } else {
-                      to_read = s * 4 - bar_off;
+                      to_read = (s * 4) - bar_off;
                   }
 
                   printf("checking from %p and %p, %zu bytes\n",
                       (void *)((unsigned char *)bars.bar2 + bar_off),
                       (void *)((unsigned char *)dest + dest_off), to_read);
                   if (memcmp((unsigned char *)bars.bar2 + bar_off,
-                          (unsigned char *)dest + dest_off, to_read)) {
+                          (unsigned char *)dest + dest_off, to_read)
+                      != 0) {
                       std::cerr << "memcmp failed" << std::endl;
                       exit(1);
                   }
@@ -57,8 +58,8 @@ int main()
     }
 
     for (auto off : offs) {
-        bar2_read_v(&bars, off, dest, bars.sizes[1] * 2 + 128);
-        compare(off, 0, bars.sizes[1] * 2 + 128);
+        bar2_read_v(&bars, off, dest, (bars.sizes[1] * 2) + 128);
+        compare(off, 0, (bars.sizes[1] * 2) + 128);
     }
 
     free(dest);

--- a/util/tests/decoders-test.cc
+++ b/util/tests/decoders-test.cc
@@ -9,7 +9,8 @@ TEST_CASE("Benchmark", "[decoders-benchmark]")
 
     dec.decode();
     BENCHMARK("Set general values") {
-        return dec.decode();
+        dec.decode();
+        return;
     };
 
     BENCHMARK("Get general values - integer") {
@@ -21,7 +22,8 @@ TEST_CASE("Benchmark", "[decoders-benchmark]")
 
     dec.channel_decode();
     BENCHMARK("Set channel values") {
-        return dec.channel_decode();
+        dec.channel_decode();
+        return;
     };
 
     BENCHMARK("Get channel values - integer") {

--- a/util/tests/decoders-test.cc
+++ b/util/tests/decoders-test.cc
@@ -8,7 +8,11 @@ TEST_CASE("Benchmark", "[decoders-benchmark]")
     TestRegisterDecoder dec { };
 
     dec.decode();
-    BENCHMARK("Set general values") { return dec.decode(); };
+    BENCHMARK("Set general values")
+    {
+        dec.decode();
+        return;
+    };
 
     BENCHMARK("Get general values - integer")
     {
@@ -20,7 +24,11 @@ TEST_CASE("Benchmark", "[decoders-benchmark]")
     };
 
     dec.channel_decode();
-    BENCHMARK("Set channel values") { return dec.channel_decode(); };
+    BENCHMARK("Set channel values")
+    {
+        dec.channel_decode();
+        return;
+    };
 
     BENCHMARK("Get channel values - integer")
     {

--- a/util/tests/fixed-test.cc
+++ b/util/tests/fixed-test.cc
@@ -21,7 +21,9 @@ TEST_CASE("Roundtrip conversions - 3 bits integer", "[fixed]")
 TEST_CASE("Saturation", "[fixed]")
 {
     const unsigned point_pos = 31;
-    const double divisor = 1UL << 31, max = 0x7fffffff / divisor, min = -1.;
+    const double divisor = 1UL << 31;
+    const double max = 0x7fffffff / divisor;
+    const double min = -1.;
     std::tuple<double, double> values[] = {{.5, .5}, {1, max}, {1.1, max}, {157, max}, {-1, min}, {-1.005, min}, {-8, min}};
     for (auto &&[v, s]: values)
         CHECK(fixed2float(float2fixed(v, point_pos, true), point_pos) == s);

--- a/util/tests/fixed-test.cc
+++ b/util/tests/fixed-test.cc
@@ -21,7 +21,9 @@ TEST_CASE("Roundtrip conversions - 3 bits integer", "[fixed]")
 TEST_CASE("Saturation", "[fixed]")
 {
     const unsigned point_pos = 31;
-    const double divisor = 1UL << 31, max = 0x7fffffff / divisor, min = -1.;
+    const double divisor = 1UL << 31;
+    const double max = 0x7fffffff / divisor;
+    const double min = -1.;
     std::tuple<double, double> values[] = { { .5, .5 }, { 1, max },
         { 1.1, max }, { 157, max }, { -1, min }, { -1.005, min }, { -8, min } };
     for (auto &&[v, s] : values)

--- a/util/tests/test-util.cc
+++ b/util/tests/test-util.cc
@@ -19,7 +19,7 @@ void dummy_dev_open(struct pcie_bars &bars)
 
     auto allocate_bar = [](volatile void *&ptr, size_t &size, size_t desired_size) {
         size = desired_size;
-        ptr = mmap(0, desired_size, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+        ptr = mmap(nullptr, desired_size, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
     };
 
     /* same sizes as our devices */

--- a/util/tests/test-util.cc
+++ b/util/tests/test-util.cc
@@ -20,7 +20,7 @@ void dummy_dev_open(struct pcie_bars &bars)
     auto allocate_bar
         = [](volatile void *&ptr, size_t &size, size_t desired_size) {
               size = desired_size;
-              ptr = mmap(0, desired_size, PROT_READ | PROT_WRITE,
+              ptr = mmap(nullptr, desired_size, PROT_READ | PROT_WRITE,
                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
           };
 

--- a/util/util-bits.h
+++ b/util/util-bits.h
@@ -18,10 +18,11 @@ static inline void clear_and_insert(uint32_t &dest, T value, uint32_t mask)
     unsigned shift = std::countr_zero(mask);
     uint32_t shifted_mask = mask >> shift;
 
-    T max, min;
+    T max;
+    T min;
     uint32_t uvalue;
     if constexpr (std::is_signed_v<T>) {
-        typedef typename std::make_unsigned<T>::type U;
+        using U = std::make_unsigned_t<T>;
 
         uint32_t umax = shifted_mask >> 1;
         /* in the case where mask == UINT32_MAX and value is signed, this would
@@ -67,7 +68,7 @@ static inline bool get_bit(uint32_t value, uint32_t mask)
 template<typename Signed>
 static inline int32_t sign_extend(uint32_t value)
 {
-    typedef typename std::make_unsigned<Signed>::type Unsigned;
+    using Unsigned = std::make_unsigned_t<Signed>;
     return (Signed)(Unsigned)value;
 }
 
@@ -98,9 +99,8 @@ static inline int32_t extract_value(uint32_t value, uint32_t mask, bool is_signe
     uint32_t intermediary = (value & mask) >> shift;
     if (is_signed) {
         return sign_extend(intermediary, popcount);
-    } else {
-        return intermediary;
     }
+    return intermediary;
 }
 
 /* XXX: remove this when there are no more users */

--- a/util/util-bits.h
+++ b/util/util-bits.h
@@ -18,10 +18,11 @@ static inline void clear_and_insert(uint32_t &dest, T value, uint32_t mask)
     unsigned shift = std::countr_zero(mask);
     uint32_t shifted_mask = mask >> shift;
 
-    T max, min;
+    T max;
+    T min;
     uint32_t uvalue;
     if constexpr (std::is_signed_v<T>) {
-        typedef typename std::make_unsigned<T>::type U;
+        using U = std::make_unsigned_t<T>;
 
         uint32_t umax = shifted_mask >> 1;
         /* in the case where mask == UINT32_MAX and value is signed, this would
@@ -68,7 +69,7 @@ static inline bool get_bit(uint32_t value, uint32_t mask)
 
 template <typename Signed> static inline int32_t sign_extend(uint32_t value)
 {
-    typedef typename std::make_unsigned<Signed>::type Unsigned;
+    using Unsigned = std::make_unsigned_t<Signed>;
     return (Signed)(Unsigned)value;
 }
 
@@ -101,9 +102,8 @@ static inline int32_t extract_value(
     uint32_t intermediary = (value & mask) >> shift;
     if (is_signed) {
         return sign_extend(intermediary, popcount);
-    } else {
-        return intermediary;
     }
+    return intermediary;
 }
 
 /* XXX: remove this when there are no more users */

--- a/util/util.cc
+++ b/util/util.cc
@@ -12,8 +12,7 @@ size_t get_index(std::string_view value, const std::vector<std::string> &value_l
     auto it = std::ranges::find(value_list, value);
     if (it != value_list.end())
         return it - value_list.begin();
-    else
-        throw std::runtime_error("option must be one of " + list_of_keys(value_list));
+    throw std::runtime_error("option must be one of " + list_of_keys(value_list));
 }
 
 void clear_and_insert_index(uint32_t &dest, uint32_t mask, std::string_view value, const std::vector<std::string> &value_list)
@@ -23,7 +22,8 @@ void clear_and_insert_index(uint32_t &dest, uint32_t mask, std::string_view valu
 
 uint32_t float2fixed(double v, unsigned point_pos, bool saturate)
 {
-    const uint32_t max_value_rep = 0x7fffffff, min_value_rep = 0x80000000;
+    const uint32_t max_value_rep = 0x7fffffff;
+    const uint32_t min_value_rep = 0x80000000;
 
     /* we know a 32-bit value fits inside the significand of a double, so these are exact */
     const double max_value = fixed2float(max_value_rep, point_pos);
@@ -66,5 +66,5 @@ std::string list_of_keys(const std::vector<std::string> &v)
 {
     auto b = v.begin();
     return std::accumulate(std::next(b), v.end(), *b,
-        [](std::string a, std::string b) { return a + ", " + b ; });
+        [](const std::string &a, const std::string &b) { return a + ", " + b ; });
 }

--- a/util/util.cc
+++ b/util/util.cc
@@ -13,9 +13,8 @@ size_t get_index(
     auto it = std::ranges::find(value_list, value);
     if (it != value_list.end())
         return it - value_list.begin();
-    else
-        throw std::runtime_error(
-            "option must be one of " + list_of_keys(value_list));
+    throw std::runtime_error(
+        "option must be one of " + list_of_keys(value_list));
 }
 
 void clear_and_insert_index(uint32_t &dest, uint32_t mask,
@@ -26,7 +25,8 @@ void clear_and_insert_index(uint32_t &dest, uint32_t mask,
 
 uint32_t float2fixed(double v, unsigned point_pos, bool saturate)
 {
-    const uint32_t max_value_rep = 0x7fffffff, min_value_rep = 0x80000000;
+    const uint32_t max_value_rep = 0x7fffffff;
+    const uint32_t min_value_rep = 0x80000000;
 
     /* we know a 32-bit value fits inside the significand of a double, so these
      * are exact */
@@ -77,5 +77,7 @@ std::string list_of_keys(const std::vector<std::string> &v)
 {
     auto b = v.begin();
     return std::accumulate(std::next(b), v.end(), *b,
-        [](std::string a, std::string b) { return a + ", " + b; });
+        [](const std::string &a, const std::string &b) {
+            return a + ", " + b;
+        });
 }

--- a/util/util_sdb.h
+++ b/util/util_sdb.h
@@ -18,7 +18,7 @@
  * makes it possible to gate functionality behind version checks. If \p
  * device_match is null, \p pos is ignored and this function simply prints all
  * SDB information. */
-std::optional<struct sdb_device_info> read_sdb(struct pcie_bars *, device_match_fn, unsigned);
+std::optional<struct sdb_device_info> read_sdb(struct pcie_bars *, const device_match_fn &, unsigned);
 
 std::vector<struct sdb_synthesis_info> get_synthesis_info(struct pcie_bars *);
 

--- a/util/util_sdb.h
+++ b/util/util_sdb.h
@@ -19,7 +19,7 @@
  * device_match is null, \p pos is ignored and this function simply prints all
  * SDB information. */
 std::optional<struct sdb_device_info> read_sdb(
-    struct pcie_bars *, device_match_fn, unsigned);
+    struct pcie_bars *, const device_match_fn &, unsigned);
 
 std::vector<struct sdb_synthesis_info> get_synthesis_info(struct pcie_bars *);
 


### PR DESCRIPTION
Testing at least two options: clang-tidy+analyzer, and cppcheck

Could try and use https://github.com/SonarSource/sonarqube-scan-action , but requires creating an account and stuff, even if supposedly free for open source (does seem to be free: <https://www.sonarsource.com/solutions/commitment-to-open-source/>)

Would like to use GCC -fanalyzer, but so far it's not recommended for C++

https://github.com/cpplint/cpplint?tab=readme-ov-file is google-specific, but could try it at least locally to see where it complains and if it's compatible

There's also https://github.com/verateam/vera

Might be best to have a separate job for this, since I don't need to run it for every build. And separate jobs for each tool would also speed up things. Perhaps add flags to fail if errors are found?

Another nice addition would be running the testsuite under sanitizers