### PR TITLE
si57x_ctrl: add timeout to busy polling.

### DIFF
--- a/include/modules/si57x_ctrl.h
+++ b/include/modules/si57x_ctrl.h
@@ -32,6 +32,12 @@ class Controller: public RegisterDecoderController {
     /** The device's internal crystal frequency. */
     double fxtal;
 
+    /** Update all registers and return state of busy flag. */
+    bool get_busy();
+    /** Loop until timeout while busy, return immediately otherwise. Updates all
+     * registers every iteration. Returns the final state of the busy flag. */
+    bool still_busy();
+
   public:
     /** The startup frequency has to be provided if read_startup_regs() is going
      * to be called. */


### PR DESCRIPTION
When the SI57x IC isn't on the I2C bus, I2C transactions might never conclude, leaving the si57x_ctrl core perenially busy. This situation can happen with BPM boards which aren't fitted with digitizer boards on both of its FMC slots.

Since we added the get_busy() function in order to simplify the implementation of still_busy(), we also use it in write_params(), to avoid repetition.

The 2 second timeout was defined by the FPGA core developer, @augustofg.